### PR TITLE
Add a test function for extracting patches on the two sides of an edge.

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -206,6 +206,21 @@ inline Eigen::Matrix3d ConvertToEigenMatrix(const std::vector<std::vector<double
     return eigen_matrix;
 }
 
+// void create_square_meshGrid( unsigned square_size, cv::Mat &meshGrid ) 
+// {
+
+// }
+
+template< typename T >
+T rad_to_deg( T theta ) {
+    return theta * (180.0 / M_PI);
+}
+
+template< typename T >
+T deg_to_rad( T theta ) {
+    return theta * (M_PI / 180.0);
+}
+
 // wasn't used in the original code, but kept for reference
 
 // /*

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -12,10 +12,11 @@
 
 #include "test_include/test_depths_and_pose.hpp"
 #include "test_include/test_third_order_edges.hpp"
+#include "test_include/test_NCC.hpp"
 
 //> Activate the tests here
-#define TEST_TOED_EDGES             (true)
-#define TEST_NCC                    (false)
+#define TEST_TOED_EDGES             (false)
+#define TEST_NCC                    (true)
 #define TEST_GRADIENT_DEPTHS        (false)
 #define TEST_RELATIVE_POSE          (false)
 #define TEST_GCC_CONSTRAINT         (false)

--- a/test/test_include/test_NCC.hpp
+++ b/test/test_include/test_NCC.hpp
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <opencv2/opencv.hpp>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+// #include "./test_third_order_edges.hpp"
+#include "../include/utility.h"
+#include "../include/definitions.h"
+
+template<typename T>
+T Uniform_Random_Number_Generator(T range_from, T range_to) {
+    std::random_device                                          rand_dev;
+    std::mt19937                                                rng(rand_dev());
+    std::uniform_int_distribution<std::mt19937::result_type>    distr(range_from, range_to);
+    return distr(rng);
+}
+
+std::pair<cv::Point2d, cv::Point2d> get_Orthogonal_Shifted_Points( const Edge edgel )
+{
+    double shifted_x1 = edgel.location.x + ORTHOGONAL_SHIFT_MAG * (std::sin(edgel.orientation));
+    double shifted_y1 = edgel.location.y + ORTHOGONAL_SHIFT_MAG * (-std::cos(edgel.orientation));
+    double shifted_x2 = edgel.location.x + ORTHOGONAL_SHIFT_MAG * (-std::sin(edgel.orientation));
+    double shifted_y2 = edgel.location.y + ORTHOGONAL_SHIFT_MAG * (std::cos(edgel.orientation));
+
+    cv::Point2d shifted_point_plus(shifted_x1, shifted_y1);
+    cv::Point2d shifted_point_minus(shifted_x2, shifted_y2);
+
+    return {shifted_point_plus, shifted_point_minus};
+}
+
+void get_patch_on_one_edge_side( cv::Point2d shifted_point, double theta, \
+                                 cv::Mat &patch_coord_x, cv::Mat &patch_coord_y, \
+                                 cv::Mat &patch_val, const cv::Mat img ) 
+{
+    int half_patch_size = floor(PATCH_SIZE / 2);
+    for (int i = -half_patch_size; i <= half_patch_size; i++) {
+        for (int j = -half_patch_size; j <= half_patch_size; j++) {
+            //> get the rotated coordinate
+            cv::Point2d rotated_point(cos(theta)*(i) - sin(theta)*(j) + shifted_point.x, sin(theta)*(i) + cos(theta)*(j) + shifted_point.y);
+            patch_coord_x.at<int>(i + half_patch_size, j + half_patch_size) = rotated_point.x;
+            patch_coord_y.at<int>(i + half_patch_size, j + half_patch_size) = rotated_point.y;
+
+            //> get the image intensity of the rotated coordinate
+            double interp_val = Bilinear_Interpolation<double>(img, rotated_point);
+            patch_val.at<double>(i + half_patch_size, j + half_patch_size) = interp_val;
+        }
+    }
+}
+
+void f_TEST_NCC() 
+{
+    std::string source_dataset_folder = "/gpfs/data/bkimia/Datasets/ETH3D/";
+    std::string dataset_sequence_path = "stereo/delivery_area/stereo_pairs/";
+    std::string stereo_pair_name = "images_rig_cam4-1477843917481127523.png-images_rig_cam5-1477843917481127523.png";
+    std::string img_path = source_dataset_folder + dataset_sequence_path + stereo_pair_name + "/im0.png";
+    
+    const cv::Mat img = cv::imread(img_path, cv::IMREAD_GRAYSCALE);
+    const int img_height = img.rows;
+    const int img_width  = img.cols;
+    std::cout << "image dimension: (" << img_height << ", " << img_width << ")" << std::endl;
+
+    ThirdOrderEdgeDetectionCPU toed_engine(img_height, img_width);
+    
+    LOG_INFO("Running third-order edge detector...");
+    std::vector<Edge> toed_edges = get_third_order_edges_(img, toed_engine);
+
+    Edge target_edge;
+    while (true) {
+        int rand_edge_idx = Uniform_Random_Number_Generator< int >(0, toed_edges.size()-1);
+        target_edge = toed_edges[rand_edge_idx]; 
+        if (fabs(fabs(target_edge.orientation) - fabs(M_PI / 4.0)) < 0.02)
+            break;
+    }
+    
+    std::cout << "Picked edge: (" << target_edge.location.x << ", " << target_edge.location.y << ", " << target_edge.orientation << ")" << std::endl;
+    std::cout << "Orientation in degree: " << rad_to_deg<double>(target_edge.orientation) << std::endl;
+
+    std::pair<cv::Point2d, cv::Point2d> shifted_points = get_Orthogonal_Shifted_Points( target_edge );
+
+    cv::Mat patch_coord_x_plus  = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_plus  = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_x_minus = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_minus = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_plus          = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_minus         = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+
+    //> get the patches on the two sides of the edge
+    get_patch_on_one_edge_side( shifted_points.first,  target_edge.orientation, patch_coord_x_plus,  patch_coord_y_plus,  patch_plus,  img );
+    get_patch_on_one_edge_side( shifted_points.second, target_edge.orientation, patch_coord_x_minus, patch_coord_y_minus, patch_minus, img );
+
+    std::cout << "Shifted point (+) location: (" << shifted_points.first.x << ", " << shifted_points.first.y << ")" << std::endl;
+    std::cout << "Patch (+) coordinates: " << std::endl;
+    std::cout << patch_coord_x_plus << std::endl;
+    std::cout << patch_coord_y_plus << std::endl;
+
+    std::cout << "Shifted point (-) location: (" << shifted_points.second.x << ", " << shifted_points.second.y << ")" << std::endl;
+    std::cout << "Patch (-) coordinates: " << std::endl;
+    std::cout << patch_coord_x_minus << std::endl;
+    std::cout << patch_coord_y_minus << std::endl;
+
+    if (patch_plus.type() != CV_32F) {
+        patch_plus.convertTo(patch_plus, CV_32F);
+    }
+    if (patch_minus.type() != CV_32F) {
+        patch_minus.convertTo(patch_minus, CV_32F);
+    }
+}

--- a/test/test_include/test_depths_and_pose.hpp
+++ b/test/test_include/test_depths_and_pose.hpp
@@ -352,32 +352,32 @@ cv::Point2d Epipolar_Shift(
 }
 
 //> MARK: MAIN TESTS FOR DEPTHS AND POSE ESTIMATIONS
-void f_TEST_NCC() {
-    cv::Mat patch1 = (cv::Mat_<double>(7, 7) << 192, 195, 189, 183, 187, 184, 190,
-                      187, 185, 185, 186, 188, 188, 189,
-                      184, 183, 186, 187, 191, 190, 193,
-                      185, 184, 188, 188, 192, 190, 192,
-                      190, 188, 187, 190, 190, 192, 192,
-                      193, 191, 189, 192, 190, 192, 193,
-                      194, 193, 192, 194, 192, 193, 194);
-    cv::Mat patch2 = (cv::Mat_<double>(7, 7) << 193, 190, 189, 189, 191, 191, 192,
-                      188, 188, 185, 182, 184, 185, 191,
-                      181, 181, 186, 185, 185, 186, 189,
-                      180, 187, 190, 185, 186, 191, 196,
-                      186, 187, 185, 186, 187, 187, 189,
-                      191, 188, 188, 190, 189, 191, 195,
-                      190, 187, 190, 192, 191, 192, 196);
+// void f_TEST_NCC() {
+//     cv::Mat patch1 = (cv::Mat_<double>(7, 7) << 192, 195, 189, 183, 187, 184, 190,
+//                       187, 185, 185, 186, 188, 188, 189,
+//                       184, 183, 186, 187, 191, 190, 193,
+//                       185, 184, 188, 188, 192, 190, 192,
+//                       190, 188, 187, 190, 190, 192, 192,
+//                       193, 191, 189, 192, 190, 192, 193,
+//                       194, 193, 192, 194, 192, 193, 194);
+//     cv::Mat patch2 = (cv::Mat_<double>(7, 7) << 193, 190, 189, 189, 191, 191, 192,
+//                       188, 188, 185, 182, 184, 185, 191,
+//                       181, 181, 186, 185, 185, 186, 189,
+//                       180, 187, 190, 185, 186, 191, 196,
+//                       186, 187, 185, 186, 187, 187, 189,
+//                       191, 188, 188, 190, 189, 191, 195,
+//                       190, 187, 190, 192, 191, 192, 196);
 
-    //> (i) element-wise multiplication
-    cv::Mat patch_ele_mul = patch1.mul(patch2);
-    std::cout << "element-wise multiplication of two patches: " << patch_ele_mul << std::endl;
-    //> (ii) Calculate the dot product
-    double patch_dot_prod = patch1.dot(patch2);
-    std::cout << "dot product of two patches: " << patch_dot_prod << std::endl;
+//     //> (i) element-wise multiplication
+//     cv::Mat patch_ele_mul = patch1.mul(patch2);
+//     std::cout << "element-wise multiplication of two patches: " << patch_ele_mul << std::endl;
+//     //> (ii) Calculate the dot product
+//     double patch_dot_prod = patch1.dot(patch2);
+//     std::cout << "dot product of two patches: " << patch_dot_prod << std::endl;
 
-    double ncc = ComputeNCC(patch1, patch2);
-    std::cout << "NCC of two patches: " << ncc << std::endl;
-}
+//     double ncc = ComputeNCC(patch1, patch2);
+//     std::cout << "NCC of two patches: " << ncc << std::endl;
+// }
 
 void f_TEST_DEPTH_GRADIENT() {
 

--- a/test/test_include/test_third_order_edges.hpp
+++ b/test/test_include/test_third_order_edges.hpp
@@ -10,6 +10,12 @@
 #include "../include/utility.h"
 #include "../include/definitions.h"
 
+std::vector<Edge> get_third_order_edges_(const cv::Mat img, ThirdOrderEdgeDetectionCPU &toed) 
+{
+    toed.get_Third_Order_Edges(img);
+    return toed.toed_edges;
+}
+
 void f_TEST_TOED() 
 {
     std::string source_dataset_folder = "/gpfs/data/bkimia/Datasets/ETH3D/";
@@ -21,12 +27,12 @@ void f_TEST_TOED()
     const int img_height = img.rows;
     const int img_width  = img.cols;
 
-    std::shared_ptr<ThirdOrderEdgeDetectionCPU> TOED = nullptr;
-    TOED = std::shared_ptr<ThirdOrderEdgeDetectionCPU>(new ThirdOrderEdgeDetectionCPU(img_height, img_width));
+    // std::shared_ptr<ThirdOrderEdgeDetectionCPU> TOED = nullptr;
+    // TOED = std::shared_ptr<ThirdOrderEdgeDetectionCPU>(new ThirdOrderEdgeDetectionCPU(img_height, img_width));
+    ThirdOrderEdgeDetectionCPU toed_engine(img_height, img_width);
     
     LOG_INFO("Running third-order edge detector...");
-    TOED->get_Third_Order_Edges(img);
-    std::vector<Edge> edges = TOED->toed_edges;
-    std::cout << "Number of total edges = " << edges.size() << std::endl;
+    std::vector<Edge> toed_edges = get_third_order_edges_(img, toed_engine);
+    std::cout << "Number of total edges = " << toed_edges.size() << std::endl;
 
 }


### PR DESCRIPTION
In preparation for updating how patches on two sides of an edge should be extracted by adding the test function to verify its correctness. Basically, the patch orientation needs to be aligned with the edge orientation. This would avoid patch area cover the edge itself to ensure stability in extracting patch values.