### PR TITLE
Make TOED orientation in a range of pi/2 and -pi/2. Also updates test_NCC function.

### DIFF
--- a/src/toed/cpu_toed.cpp
+++ b/src/toed/cpu_toed.cpp
@@ -226,7 +226,8 @@ void ThirdOrderEdgeDetectionCPU::convolve_img()
                 TO_conv_mag = std::sqrt(TO_conv_Ix * TO_conv_Ix + TO_conv_Iy * TO_conv_Iy);
                 TO_conv_Ix /= TO_conv_mag;
                 TO_conv_Iy /= TO_conv_mag;
-                I_orient(si, sj) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                // I_orient(si, sj) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                I_orient(si, sj) = std::atan(TO_conv_Ix / -TO_conv_Iy);
                 // ---------------------------------------------------------
 
                 fx = 0;
@@ -269,7 +270,8 @@ void ThirdOrderEdgeDetectionCPU::convolve_img()
                 TO_conv_mag = std::sqrt(TO_conv_Ix * TO_conv_Ix + TO_conv_Iy * TO_conv_Iy);
                 TO_conv_Ix /= TO_conv_mag;
                 TO_conv_Iy /= TO_conv_mag;
-                I_orient(si, sj + 1) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                // I_orient(si, sj + 1) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                I_orient(si, sj + 1) = std::atan(TO_conv_Ix / -TO_conv_Iy);
                 // ----------------------------------------------------------------
 
                 fx = 0;
@@ -312,7 +314,8 @@ void ThirdOrderEdgeDetectionCPU::convolve_img()
                 TO_conv_mag = std::sqrt(TO_conv_Ix * TO_conv_Ix + TO_conv_Iy * TO_conv_Iy);
                 TO_conv_Ix /= TO_conv_mag;
                 TO_conv_Iy /= TO_conv_mag;
-                I_orient(si + 1, sj) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                // I_orient(si + 1, sj) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                I_orient(si + 1, sj) = std::atan(TO_conv_Ix / -TO_conv_Iy);
                 // ----------------------------------------------------------------
 
                 fx = 0;
@@ -355,7 +358,8 @@ void ThirdOrderEdgeDetectionCPU::convolve_img()
                 TO_conv_mag = std::sqrt(TO_conv_Ix * TO_conv_Ix + TO_conv_Iy * TO_conv_Iy);
                 TO_conv_Ix /= TO_conv_mag;
                 TO_conv_Iy /= TO_conv_mag;
-                I_orient(si + 1, sj + 1) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                // I_orient(si + 1, sj + 1) = std::atan2(TO_conv_Ix, -TO_conv_Iy);
+                I_orient(si + 1, sj + 1) = std::atan(TO_conv_Ix / -TO_conv_Iy);
             }
         }
     }

--- a/test/test_include/test_NCC.hpp
+++ b/test/test_include/test_NCC.hpp
@@ -40,8 +40,8 @@ void get_patch_on_one_edge_side( cv::Point2d shifted_point, double theta, \
         for (int j = -half_patch_size; j <= half_patch_size; j++) {
             //> get the rotated coordinate
             cv::Point2d rotated_point(cos(theta)*(i) - sin(theta)*(j) + shifted_point.x, sin(theta)*(i) + cos(theta)*(j) + shifted_point.y);
-            patch_coord_x.at<int>(i + half_patch_size, j + half_patch_size) = rotated_point.x;
-            patch_coord_y.at<int>(i + half_patch_size, j + half_patch_size) = rotated_point.y;
+            patch_coord_x.at<double>(i + half_patch_size, j + half_patch_size) = rotated_point.x;
+            patch_coord_y.at<double>(i + half_patch_size, j + half_patch_size) = rotated_point.y;
 
             //> get the image intensity of the rotated coordinate
             double interp_val = Bilinear_Interpolation<double>(img, rotated_point);
@@ -80,10 +80,10 @@ void f_TEST_NCC()
 
     std::pair<cv::Point2d, cv::Point2d> shifted_points = get_Orthogonal_Shifted_Points( target_edge );
 
-    cv::Mat patch_coord_x_plus  = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
-    cv::Mat patch_coord_y_plus  = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
-    cv::Mat patch_coord_x_minus = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
-    cv::Mat patch_coord_y_minus = cv::Mat_<int>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_x_plus  = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_plus  = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_x_minus = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_minus = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
     cv::Mat patch_plus          = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
     cv::Mat patch_minus         = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
 

--- a/test/test_include/test_third_order_edges.hpp
+++ b/test/test_include/test_third_order_edges.hpp
@@ -35,4 +35,13 @@ void f_TEST_TOED()
     std::vector<Edge> toed_edges = get_third_order_edges_(img, toed_engine);
     std::cout << "Number of total edges = " << toed_edges.size() << std::endl;
 
+    //> Optional: save third-order edges to a file
+    std::ofstream toed_file;
+    std::string file_name_for_toed = "/gpfs/data/bkimia/cchien3/Edge_Based_Visual_Odometry/test/toed.txt";
+    toed_file.open(file_name_for_toed);
+    for (int i = 0; i < toed_edges.size(); i++) {
+        toed_file << toed_edges[i].location.x << "\t" << toed_edges[i].location.y << "\t" << toed_edges[i].orientation << "\n";
+    }
+    toed_file.close();
+
 }


### PR DESCRIPTION
Initiate the change of edge orientation from the range of (pi, -pi] to (pi/2, -pi/2]. This enforces other places of the code to be changed accordingly.