### PR TITLE
Reorganize the entire code to serve for a VO pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall" CACHE STRING "" FORCE)
 
 #> Crucial flags for performance
+#> -ffast-math omitted: it optimizes away std::isinf/std::isnan
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "" FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math" CACHE STRING "" FORCE)
 
 #list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)

--- a/cmd/main_VO.cpp
+++ b/cmd/main_VO.cpp
@@ -90,7 +90,29 @@ int main(int argc, char **argv)
 		std::cerr << "File does not exist!" << std::endl;
 	}
 
-	Temporal_Matches temporal_matches(config_map);
-	temporal_matches.PerformEdgeBasedVO();
+	//> Initialize the dataset and the pipeline
+	Dataset::Ptr dataset_ = std::make_shared<Dataset>(config_map);
+	Pipeline::Ptr edge_vo_system = Pipeline::Ptr(new Pipeline(dataset_));
+
+	//> Loop over all stereo image pairs
+	size_t frame_idx = 0;
+    while (dataset_->stereo_iterator->hasNext())
+    {
+		if (!dataset_->stereo_iterator->getNext(edge_vo_system->current_frame))
+        {
+            std::cout << "No more image pairs to process" << std::endl;
+            break;
+        }
+
+		edge_vo_system->set_Stereo_Frame_Index(frame_idx);
+		edge_vo_system->Add_Stereo_Frame();
+		frame_idx++;
+
+		if (frame_idx == 2)
+			break;
+	}
+
+	// Temporal_Matches temporal_matches(config_map);
+	// temporal_matches.PerformEdgeBasedVO();
 	return 0;
 }

--- a/cmd/main_VO.cpp
+++ b/cmd/main_VO.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
             break;
         }
 
-		edge_vo_system->set_Stereo_Frame_Index(frame_idx);
+		edge_vo_system->set_Current_Stereo_Frame_Index(frame_idx);
 		edge_vo_system->Add_Stereo_Frame();
 		frame_idx++;
 

--- a/cmd/main_VO.cpp
+++ b/cmd/main_VO.cpp
@@ -6,7 +6,7 @@
 #include "../include/definitions.h"
 #include "../include/Dataset.h"
 #include "../include/Pipeline.h"
-#include "../include/EBVO.h"
+#include "../include/Temporal_Matches.h"
 
 #if USE_GLOGS
 #include <glog/logging.h>
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 		std::cerr << "File does not exist!" << std::endl;
 	}
 
-	EBVO ebvo(config_map);
-	ebvo.PerformEdgeBasedVO();
+	Temporal_Matches temporal_matches(config_map);
+	temporal_matches.PerformEdgeBasedVO();
 	return 0;
 }

--- a/config/eth3d_delivery_area.yaml
+++ b/config/eth3d_delivery_area.yaml
@@ -2,7 +2,7 @@
 
 # Dataset Details
 dataset_dir: "/oscar/data/bkimia/Datasets"
-output_dir: "/oscar/data/bkimia/jhan192/jue_dev_ebvo/Edge_Based_Visual_Odometry/outputs"
+output_dir: "./outputs"
 sequence_name: "ETH3D/stereo/delivery_area"
 dataset_type: "ETH3D"
 

--- a/include/Dataset.h
+++ b/include/Dataset.h
@@ -341,6 +341,22 @@ struct temporal_edge_pair
     std::vector<Temporal_CF_Edge_Cluster> matching_CF_edge_clusters;
 };
 
+//> One veridical quad: KF stereo correspondence + CF stereo correspondence, with cluster-like refinement data.
+//> Used by the quad-centric pipeline
+struct Veridical_Quad_Entry
+{
+    int cf_stereo_edge_mate_index;
+    Edge left_center;   //> refined left CF edge location
+    Edge right_center;  //> refined right CF edge location
+};
+
+struct Candidate_Quad_Entry
+{
+    //> pointers to Temporal_CF_Edge_Cluster
+    const Temporal_CF_Edge_Cluster *CF_left;
+    const Temporal_CF_Edge_Cluster *CF_right;
+};
+
 extern cv::Mat merged_visualization_global;
 class Dataset
 {

--- a/include/Dataset.h
+++ b/include/Dataset.h
@@ -12,6 +12,7 @@
 #include <Eigen/Geometry>
 #include <yaml-cpp/yaml.h>
 #include <opencv2/opencv.hpp>
+#include <opencv2/core/eigen.hpp>
 
 #include "definitions.h"
 #include "Frame.h"
@@ -66,7 +67,7 @@ struct SpatialGrid
         }
     }
 
-    std::vector<int> getCandidatesWithinRadius(Edge Edge, double radius)
+    std::vector<int> getCandidatesWithinRadius(Edge Edge, double radius) const
     {
         std::vector<int> candidates;
         int grid_x = static_cast<int>(Edge.location.x) / cell_size;
@@ -89,7 +90,7 @@ struct SpatialGrid
         return candidates;
     }
 
-    std::vector<int> getCandidatesWithinRadius(cv::Point2d e_location, double radius)
+    std::vector<int> getCandidatesWithinRadius(cv::Point2d e_location, double radius) const
     {
         std::vector<int> candidates;
         int grid_x = static_cast<int>(e_location.x) / cell_size;
@@ -215,6 +216,7 @@ struct Stereo_Edge_Pairs
         GT_locations_from_left_edges.clear();
         veridical_right_edges_indices.clear();
         Gamma_in_left_cam_coord.clear();
+        Gamma_in_right_cam_coord.clear();
         left_edge_descriptors.clear();
         grid_indices.clear();
         epip_line_coeffs_of_left_edges.clear();
@@ -349,7 +351,7 @@ public:
     std::unique_ptr<StereoIterator> stereo_iterator;
 
     void load_dataset(const std::string &dataset_type, std::vector<cv::Mat> &left_ref_disparity_maps, std::vector<cv::Mat> &right_ref_disparity_maps,
-                      std::vector<cv::Mat> &left_occlusion_masks, std::vector<cv::Mat> &right_occlusion_masks, int num_pairs);
+                      std::vector<cv::Mat> &left_occlusion_masks, std::vector<cv::Mat> &right_occlusion_masks);
 
     std::vector<Edge> left_edges;
     std::vector<Edge> right_edges;
@@ -384,7 +386,10 @@ public:
 
     Eigen::Matrix3d get_left_calib_matrix() { return camera_info.left.K; }
     Eigen::Matrix3d get_right_calib_matrix() { return camera_info.right.K; }
-
+    cv::Mat get_left_calib_matrix_cvMat() { cv::Mat K; cv::eigen2cv(get_left_calib_matrix(), K); return K; }
+    cv::Mat get_right_calib_matrix_cvMat() { cv::Mat K; cv::eigen2cv(get_right_calib_matrix(), K); return K; }
+    cv::Mat get_left_dist_coeff_mat() { return (cv::Mat_<double>(1, 4) << camera_info.left.distortion[0], camera_info.left.distortion[1], camera_info.left.distortion[2], camera_info.left.distortion[3]); }
+    cv::Mat get_right_dist_coeff_mat() { return (cv::Mat_<double>(1, 4) << camera_info.right.distortion[0], camera_info.right.distortion[1], camera_info.right.distortion[2], camera_info.right.distortion[3]); }
     double get_left_baseline() { return camera_info.left.T[0]; };
     double get_right_baseline() { return camera_info.right.T[0]; };
 
@@ -459,15 +464,9 @@ private:
     // functions
     void PrintDatasetInfo();
 
-    std::vector<std::pair<cv::Mat, cv::Mat>> LoadEuRoCImages(const std::string &csv_path, const std::string &left_path, const std::string &right_path, int num_images);
-
-    std::vector<std::pair<cv::Mat, cv::Mat>> LoadETH3DImages(const std::string &stereo_pairs_path, int num_images);
-
-    std::vector<cv::Mat> LoadETH3DLeftReferenceMaps(const std::string &stereo_pairs_path, int num_maps);
-
-    std::vector<cv::Mat> LoadETH3DOcclusionMasks(const std::string &stereo_pairs_path, int num_maps, bool left = true);
-
-    void LoadETH3DDisparityMaps(const std::string &stereo_pairs_path, int num_maps, std::vector<cv::Mat> &left_disparity_maps, std::vector<cv::Mat> &right_disparity_maps);
+    //> ETH3D dataset
+    std::vector<cv::Mat> LoadETH3DOcclusionMasks(const std::string &stereo_pairs_path, bool left = true);
+    void LoadETH3DDisparityMaps(const std::string &stereo_pairs_path, std::vector<cv::Mat> &left_disparity_maps, std::vector<cv::Mat> &right_disparity_maps);
 
     Utility::Ptr utility_tool = nullptr;
 };

--- a/include/Pipeline.h
+++ b/include/Pipeline.h
@@ -9,31 +9,20 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
+#include "Dataset.h"
+#include "toed/cpu_toed.hpp"
+#include "definitions.h"
 #include "Frame.h"
 #include "utility.h"
 #include "MotionTracker.h"
-
-// =====================================================================================================================
-// class Pipeline: visual odometry pipeline 
-//
-// ChangeLogs
-//    Chien  23-01-17    Initially created. 
-//
-//> (c) LEMS, Brown University
-//> Chiang-Heng Chien (chiang-heng_chien@brown.edu)
-// ======================================================================================================================
+#include "Stereo_Matches.h"
+#include "Temporal_Matches.h"
 
 //> status of the visual odometry pipeline
-enum class PipelineStatus { STATUS_INITIALIZATION, \
-                            STATUS_GET_AND_MATCH_SIFT, \
-                            STATUS_ESTIMATE_RELATIVE_POSE };
-
-//> Defined operator used to create a rank-ordered list of feature correspondences
-struct less_than_Eucl_Dist {
-    inline bool operator() ( const cv::DMatch& Des1, const cv::DMatch& Des2 ) {
-        return ( Des1.distance < Des2.distance );
-    }
-};
+enum class PipelineStatus { STATUS_IMG_PREPARATION, \
+                            STATUS_GET_STEREO_EDGE_CORRESPONDENCES, \
+                            STATUS_GET_TEMPORAL_EDGE_CORRESPONDENCES, \
+                            STATUS_TRACK_CAMERA_MOTION };
 
 class Pipeline {
 
@@ -41,20 +30,28 @@ public:
     //EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
     typedef std::shared_ptr<Pipeline> Ptr;
 
-    //> Constructor (nothing special)
-    Pipeline();
+    //> Constructor
+    Pipeline(Dataset::Ptr dataset);
 
     //> When new frame is created, jump to the pipeline status
-    bool Add_Frame(Frame::Ptr frame);
+    bool Add_Stereo_Frame();
+
+    void prepare_Stereo_Images();
+    void get_Stereo_Edge_Correspondences();
+    void get_Temporal_Edge_Correspondences();
+
+    //> setters
+    void set_Stereo_Frame_Index(size_t frame_idx) { stereo_frame_idx = frame_idx; }
 
     //> get the pipeline status
     PipelineStatus get_Status() const { return status_; }
 
     //> Print pipeline status
     std::string print_Status() const {
-        if      (status_ == PipelineStatus::STATUS_INITIALIZATION)          return std::string("STATUS_INITIALIZATION");
-        else if (status_ == PipelineStatus::STATUS_GET_AND_MATCH_SIFT)      return std::string("STATUS_GET_AND_MATCH_SIFT");
-        else if (status_ == PipelineStatus::STATUS_ESTIMATE_RELATIVE_POSE)  return std::string("STATUS_ESTIMATE_RELATIVE_POSE");
+        if      (status_ == PipelineStatus::STATUS_IMG_PREPARATION)                      return std::string("STATUS_IMG_PREPARATION");
+        else if (status_ == PipelineStatus::STATUS_GET_STEREO_EDGE_CORRESPONDENCES)      return std::string("STATUS_GET_STEREO_EDGE_CORRESPONDENCES");
+        else if (status_ == PipelineStatus::STATUS_GET_TEMPORAL_EDGE_CORRESPONDENCES)    return std::string("STATUS_GET_TEMPORAL_EDGE_CORRESPONDENCES");
+        else if (status_ == PipelineStatus::STATUS_TRACK_CAMERA_MOTION)                  return std::string("STATUS_TRACK_CAMERA_MOTION");
         LOG_ERROR("[Developer Error] Need to apend status string in print_Status() function!");
         return std::string("STATUS_UNKNOWN");
     }
@@ -62,22 +59,50 @@ public:
     //> Interact with the main function
     bool send_control_to_main = true;
 
-    //> For now these member variables are used for dubugging purposes
-    int Num_Of_SIFT_Features;
-    int Num_Of_Good_Feature_Matches;
+    //> Stereo frames
+    StereoFrame keyframe, current_frame;
 
 private:
-    /**
-     * Extract features of the current frame
-     * @return Num of SIFT features
-     */
-    int get_Features();
+    size_t stereo_frame_idx;
+    SpatialGrid left_spatial_grids;
+    SpatialGrid right_spatial_grids;
 
-    /**
-     * Find the corresponding features in right image of current_frame_
-     * @return Num of SIFT feature correspondences
-     */
-    int get_Feature_Correspondences();
+    void initialize_TOED_and_Spatial_Grids() {
+        //> Set the image dimensions
+        dataset_->set_height(current_frame.left_image_undistorted.rows);
+        dataset_->set_width(current_frame.left_image_undistorted.cols);
+
+        //> Initialize the third-order edge detector class pointer
+        TOED = ThirdOrderEdgeDetectionCPU::Ptr(new ThirdOrderEdgeDetectionCPU(dataset_->get_height(), dataset_->get_width()));
+
+        //> Initialize the spatial grids with a cell size of defined GRID_SIZE
+        left_spatial_grids = SpatialGrid(dataset_->get_width(), dataset_->get_height(), GRID_SIZE);
+        right_spatial_grids = SpatialGrid(dataset_->get_width(), dataset_->get_height(), GRID_SIZE);
+    };
+
+    void ProcessEdges(const cv::Mat &image, std::vector<Edge> &edges);
+
+    void set_Keyframe() {
+        keyframe = current_frame;
+        keyframe_stereo_edge_mates = current_frame_stereo_edge_mates;
+        keyframe_stereo_left_constructor = current_frame_stereo_left_constructor;
+        keyframe_stereo_left_constructor.stereo_frame = &keyframe;
+        keyframe_stereo_left_constructor.left_disparity_map = keyframe.left_disparity_map;
+        keyframe_stereo_left_constructor.right_disparity_map = keyframe.right_disparity_map;
+
+        //> reset current_frame
+        current_frame = StereoFrame();
+        current_frame_stereo_edge_mates.clear();
+        current_frame_stereo_left_constructor.clean_up_vector_data_structures();
+    }
+
+    void set_Stereo_Left_Constructor() {
+        current_frame_stereo_edge_mates.clear();
+        current_frame_stereo_left_constructor.clean_up_vector_data_structures();
+        current_frame_stereo_left_constructor.stereo_frame = &current_frame;
+        current_frame_stereo_left_constructor.left_disparity_map = current_frame.left_disparity_map;
+        current_frame_stereo_left_constructor.right_disparity_map = current_frame.right_disparity_map;
+    }
 
     /**
      * Estimate camera poses
@@ -85,10 +110,30 @@ private:
      */
     bool track_Camera_Motion();
 
+    //> Evaluations are enabled if the dataset has ground truth disparity maps
+    std::vector<cv::Mat> left_ref_disparity_maps, right_ref_disparity_maps;
+    std::vector<cv::Mat> left_occlusion_masks, right_occlusion_masks;
+
     //> Status of the Visual Odometry Pipeline
-    PipelineStatus status_ = PipelineStatus::STATUS_INITIALIZATION;
+    PipelineStatus status_ = PipelineStatus::STATUS_IMG_PREPARATION;
+
+    //> Stereo edge pairs constructor (processing stereo edge correspondences before finalizing the 1-1 stereo edge mapping)
+    Stereo_Edge_Pairs keyframe_stereo_left_constructor;
+    Stereo_Edge_Pairs current_frame_stereo_left_constructor;
+
+    //> Final 1-1 stereo edge pairs for keyframe and current frame
+    std::vector<final_stereo_edge_pair> keyframe_stereo_edge_mates;
+    std::vector<final_stereo_edge_pair> current_frame_stereo_edge_mates;
+
+    //> Keyframe <-> current frame edge pairs
+    std::vector<temporal_edge_pair> left_temporal_edge_mates;
+    std::vector<temporal_edge_pair> right_temporal_edge_mates;
 
     //> Pointers to the classes
+    Dataset::Ptr dataset_ = nullptr;
+    ThirdOrderEdgeDetectionCPU::Ptr TOED = nullptr;
+    Stereo_Matches::Ptr stereo_matches_engine = nullptr;
+    Temporal_Matches::Ptr temporal_matches_engine = nullptr;
     Frame::Ptr Current_Frame  = nullptr;
     Frame::Ptr Previous_Frame = nullptr;
     Utility::Ptr utility_tool = nullptr;

--- a/include/Pipeline.h
+++ b/include/Pipeline.h
@@ -41,7 +41,7 @@ public:
     void get_Temporal_Edge_Correspondences();
 
     //> setters
-    void set_Stereo_Frame_Index(size_t frame_idx) { stereo_frame_idx = frame_idx; }
+    void set_Current_Stereo_Frame_Index(size_t frame_idx) { stereo_current_frame_idx = frame_idx; }
 
     //> get the pipeline status
     PipelineStatus get_Status() const { return status_; }
@@ -63,7 +63,8 @@ public:
     StereoFrame keyframe, current_frame;
 
 private:
-    size_t stereo_frame_idx;
+    size_t stereo_key_frame_idx;
+    size_t stereo_current_frame_idx;
     SpatialGrid left_spatial_grids;
     SpatialGrid right_spatial_grids;
 
@@ -83,6 +84,8 @@ private:
     void ProcessEdges(const cv::Mat &image, std::vector<Edge> &edges);
 
     void set_Keyframe() {
+        stereo_key_frame_idx = stereo_current_frame_idx;
+        
         keyframe = current_frame;
         keyframe_stereo_edge_mates = current_frame_stereo_edge_mates;
         keyframe_stereo_left_constructor = current_frame_stereo_left_constructor;

--- a/include/Stereo_Iterator.h
+++ b/include/Stereo_Iterator.h
@@ -41,6 +41,10 @@ struct StereoFrame
     std::vector<Edge> left_edges;
     std::vector<Edge> right_edges;
 
+    //> disparity maps
+    cv::Mat left_disparity_map;
+    cv::Mat right_disparity_map;
+
     // bool has_gt = false;
     Eigen::Matrix3d gt_rotation;
     Eigen::Vector3d gt_translation;

--- a/include/Stereo_Matches.h
+++ b/include/Stereo_Matches.h
@@ -34,11 +34,13 @@ public:
     Stereo_Matches() { utility_tool = std::make_shared<Utility>(); };
     ~Stereo_Matches() {};
 
+    typedef std::shared_ptr<Stereo_Matches> Ptr;
+
     //> main function to get stereo edge pairs
-    Frame_Evaluation_Metrics get_Stereo_Edge_Pairs(Dataset &dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, size_t frame_idx);
+    Frame_Evaluation_Metrics get_Stereo_Edge_Pairs(Dataset::Ptr dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, size_t frame_idx);
 
     //> filtering methods
-    void apply_Epipolar_Line_Distance_Filtering(Stereo_Edge_Pairs &stereo_frame_edge_pairs, Dataset &dataset, const std::vector<Edge> right_edges, const std::string &output_dir = "", bool is_left = true, size_t frame_idx = 0, int num_random_edges_for_distribution = 0);
+    void apply_Epipolar_Line_Distance_Filtering(Stereo_Edge_Pairs &stereo_frame_edge_pairs, Dataset::Ptr dataset, const std::vector<Edge> right_edges, const std::string &output_dir = "", bool is_left = true, size_t frame_idx = 0, int num_random_edges_for_distribution = 0);
     void apply_Disparity_Filtering(Stereo_Edge_Pairs &stereo_frame_edge_pairs, const std::string &output_dir = "", size_t frame_idx = 0, bool is_left = true);
     void apply_SIFT_filtering(Stereo_Edge_Pairs &stereo_frame_edge_pairs, double sift_dist_threshold, const std::string &output_dir = "", size_t frame_idx = 0, bool is_left = true);
     void apply_NCC_Filtering(Stereo_Edge_Pairs &stereo_frame_edge_pairs, const std::string &output_dir, size_t frame_idx, bool is_left = true);
@@ -61,8 +63,8 @@ public:
     void add_edges_to_spatial_grid(Stereo_Edge_Pairs &stereo_frame_edge_pairs, SpatialGrid &spatial_grid, bool is_left);
 
     //>
-    void Find_Stereo_GT_Locations(Dataset &dataset, const cv::Mat left_disparity_map, const StereoFrame &stereo_frame, Stereo_Edge_Pairs &stereo_frame_edge_pairs, bool is_left);
-    void get_Stereo_Edge_GT_Pairs(Dataset &dataset, const StereoFrame &stereo_frame, Stereo_Edge_Pairs &stereo_frame_edge_pairs, bool is_left);
+    void Find_Stereo_GT_Locations(Dataset::Ptr dataset, const cv::Mat left_disparity_map, const StereoFrame &stereo_frame, Stereo_Edge_Pairs &stereo_frame_edge_pairs, bool is_left);
+    void get_Stereo_Edge_GT_Pairs(Dataset::Ptr dataset, const StereoFrame &stereo_frame, Stereo_Edge_Pairs &stereo_frame_edge_pairs, bool is_left);
     void record_Filter_Distribution(const std::string &filter_name, const std::vector<double> &filter_values, const std::vector<int> &is_veridical, const std::string &output_dir, size_t frame_idx = 0);
     void record_Ambiguity_Distribution(const std::string &stage_name, const Stereo_Edge_Pairs &stereo_frame_edge_pairs, const std::string &output_dir, size_t frame_idx);
 
@@ -70,7 +72,7 @@ private:
     //> visualization methods
     void record_correspondences_for_visualization(const Stereo_Edge_Pairs &stereo_frame_edge_pairs, const std::string &output_dir, size_t frame_idx, int num_samples = 10);
     std::vector<Eigen::Vector3d> CalculateEpipolarLine(const Eigen::Matrix3d &fund_mat, const std::vector<Edge> &edges);
-    void write_Stereo_Edge_Pairs_to_file(Dataset &dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, int frame_idx);
+    void write_Stereo_Edge_Pairs_to_file(Dataset::Ptr dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, int frame_idx);
 
     //> evaluation methods
     std::vector<int> get_right_edge_indices_close_to_GT_location(const StereoFrame &stereo_frame, const cv::Point2d GT_location, double GT_orientation, const std::vector<int> right_candidate_edge_indices, const double dist_tol, const double orient_tol, bool is_left = true);

--- a/include/Temporal_Matches.h
+++ b/include/Temporal_Matches.h
@@ -24,17 +24,26 @@
 class Temporal_Matches
 {
 public:
-    Temporal_Matches(YAML::Node config_map);
+    typedef std::shared_ptr<Temporal_Matches> Ptr;
+
+    Temporal_Matches(Dataset::Ptr dataset);
+
+    void get_Temporal_Edge_Pairs( \
+        std::vector<final_stereo_edge_pair> &current_frame_stereo_edge_mates, \
+        std::vector<temporal_edge_pair> &left_temporal_edge_mates, std::vector<temporal_edge_pair> &right_temporal_edge_mates, \
+        const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids, \
+        const StereoFrame &keyframe, const StereoFrame &current_frame, \
+        size_t frame_idx);
 
     // Main function to perform edge-based visual odometry
     void PerformEdgeBasedVO();
-    void ProcessEdges(const cv::Mat &image,
-                      std::shared_ptr<ThirdOrderEdgeDetectionCPU> &toed,
-                      std::vector<Edge> &edges);
+    // void ProcessEdges(const cv::Mat &image,
+    //                   std::shared_ptr<ThirdOrderEdgeDetectionCPU> &toed,
+    //                   std::vector<Edge> &edges);
     void add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids);
 
     //> filtering methods
-    void apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, SpatialGrid &spatial_grid, double grid_radius = 1.0, bool b_is_left = true);
+    void apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, const SpatialGrid &spatial_grid, double grid_radius = 1.0, bool b_is_left = true);
     void apply_orientation_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                      const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                      double orientation_threshold, bool b_is_left);
@@ -82,11 +91,11 @@ public:
 
 private:
     //> CH: shared pointer to the class of third-order edge detector
-    std::shared_ptr<ThirdOrderEdgeDetectionCPU> TOED = nullptr;
+    // std::shared_ptr<ThirdOrderEdgeDetectionCPU> TOED = nullptr;
     //> JH: dataset we are working on and its corresponding spatial grid
-    Dataset dataset;
-    SpatialGrid left_spatial_grids;
-    SpatialGrid right_spatial_grids;
+    Dataset::Ptr dataset;
+    // SpatialGrid left_spatial_grids;
+    // SpatialGrid right_spatial_grids;
 };
 
 #endif // EBVO_H

--- a/include/Temporal_Matches.h
+++ b/include/Temporal_Matches.h
@@ -10,22 +10,18 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-// =======================================================================================================
-// Temporal_Matches: Main structure of LEMS Edge-Based Visual Odometry
-//
-// ChangeLogs
-//    Jue  25-06-10    Created to reorganize VO.
-//
-//> (c) LEMS, Brown University
-//> Chiang-Heng Chien (chiang-heng_chien@brown.edu)
-//> Jue Han (jhan192@brown.edu)
-// =======================================================================================================
 
-//> One KF stereo correspondence -> all veridical CF stereo correspondences (multiple quads per KF)
+//> One KF stereo correspondence -> veridical quads + candidate quads (from spatial grid).
 struct KF_Veridical_Quads
 {
     const final_stereo_edge_pair *KF_stereo_mate;
-    std::vector<const final_stereo_edge_pair *> veridical_CF_stereo_mates;
+    std::vector<Veridical_Quad_Entry> veridical_quads;
+    std::vector<Candidate_Quad_Entry> candidate_quads;
+
+    Eigen::Vector3d projected_point_left;
+    Eigen::Vector3d projected_point_right;
+    double projected_orientation_left;
+    double projected_orientation_right;
 };
 
 class Temporal_Matches
@@ -35,39 +31,41 @@ public:
 
     Temporal_Matches(Dataset::Ptr dataset);
 
-    void get_Temporal_Edge_Pairs( \
-        std::vector<final_stereo_edge_pair> &current_frame_stereo_edge_mates, \
-        std::vector<temporal_edge_pair> &left_temporal_edge_mates, std::vector<temporal_edge_pair> &right_temporal_edge_mates, \
-        const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids, \
-        const StereoFrame &keyframe, const StereoFrame &current_frame, \
-        size_t frame_idx);
+    //> Quad-centric pipeline: build veridical quads and apply all filters in one flow.
+    //> Output: filtered_quads. Optionally populates left/right temporal_edge_mates for backward compatibility.
+    void get_Temporal_Edge_Pairs_from_Quads(
+        std::vector<KF_Veridical_Quads> &filtered_quads,
+        const std::vector<final_stereo_edge_pair> &KF_stereo_edge_mates,
+        const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
+        const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids,
+        Stereo_Edge_Pairs &last_keyframe_stereo, Stereo_Edge_Pairs &current_frame_stereo,
+        const StereoFrame &keyframe, const StereoFrame &current_frame,
+        size_t keyframe_idx, size_t current_frame_idx);
 
     void add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids);
 
-    //> filtering methods
+    //> Build veridical quads in one step (combines Find_Veridical + find_Veridical_Quads).
+    void build_Veridical_Quads(
+        std::vector<KF_Veridical_Quads> &out,
+        const std::vector<final_stereo_edge_pair> &KF_stereo_edge_mates,
+        const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
+        Stereo_Edge_Pairs &last_keyframe_stereo, Stereo_Edge_Pairs &current_frame_stereo,
+        const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids);
+
+    //> filtering methods (temporal_edge_pair - legacy)
     void apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, const SpatialGrid &spatial_grid, double grid_radius = 1.0, bool b_is_left = true);
+
+    //> Quad-centric filter methods (operate on std::vector<KF_Veridical_Quads>)
+    void apply_spatial_grid_filtering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids, double grid_radius = 1.0);
+    void apply_orientation_filtering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, double orientation_threshold);
+    void apply_NCC_filtering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, double ncc_val_threshold, const cv::Mat &keyframe_left_image, const cv::Mat &keyframe_right_image, const cv::Mat &cf_left_image, const cv::Mat &cf_right_image);
+    void apply_SIFT_filtering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, double sift_dist_threshold);
+    void apply_best_nearly_best_filtering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, double threshold, const std::string scoring_type);
+    void apply_photometric_refinement_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, const StereoFrame &keyframe, const StereoFrame &current_frame);
+    void apply_temporal_edge_clustering_quads(std::vector<KF_Veridical_Quads> &quads_by_kf, bool b_cluster_by_orientation = true);
     void apply_orientation_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                      const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                      double orientation_threshold, bool b_is_left);
-
-    void apply_SIFT_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
-                              const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
-                              double sift_dist_threshold, bool b_is_left);
-    void apply_NCC_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
-                             const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
-                             double ncc_val_threshold,
-                             const cv::Mat &keyframe_image, const cv::Mat &current_image, bool b_is_left);
-    void apply_best_nearly_best_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, double threshold, const std::string scoring_type);
-
-    void apply_mate_consistency_filtering(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
-                                          std::vector<temporal_edge_pair> &right_temporal_edge_mates);
-
-    void apply_photometric_refinement(std::vector<temporal_edge_pair> &temporal_edge_mates,
-                                      const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
-                                      const StereoFrame &keyframe, const StereoFrame &current_frame,
-                                      bool b_is_left);
-
-    void apply_temporal_edge_clustering(std::vector<temporal_edge_pair> &temporal_edge_mates, bool b_cluster_by_orientation = true);
 
     void min_Edge_Photometric_Residual_by_Gauss_Newton(
         /* inputs */
@@ -77,26 +75,25 @@ public:
         Eigen::Vector2d &refined_disparity, double &refined_final_score, bool &refined_validity, std::vector<double> &residual_log,
         /* optional inputs */
         int max_iter = 20, double tol = 1e-3, double huber_delta = 3.0, bool b_verbose = false);
-
-    void Find_Veridical_Edge_Correspondences_on_CF(std::vector<temporal_edge_pair> &temporal_edge_mates,
-                                                   const std::vector<final_stereo_edge_pair> &KF_stereo_edge_mates,
-                                                   const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
-                                                   Stereo_Edge_Pairs &last_keyframe_stereo, Stereo_Edge_Pairs &current_frame_stereo,
-                                                   SpatialGrid &spatial_grid, bool b_is_left, double gt_dist_threshold = 1.0);
-    
-    //> Construct veridical quads grouped by KF: each KF stereo correspondence maps to all veridical CF stereo
-    //> correspondences (left/right agree), so total quads = sum over KF of veridical_CF_stereo_mates.size().
-    std::vector<KF_Veridical_Quads> find_Veridical_Quads(
-        const std::vector<temporal_edge_pair> &left_temporal_edge_mates,
-        const std::vector<temporal_edge_pair> &right_temporal_edge_mates,
-        const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates);
-    
+   
     double orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset);
 
 private:
-    //> Evaluations
-    void Evaluate_Temporal_Edge_Pairs(const std::vector<temporal_edge_pair> &temporal_edge_mates,
-        size_t frame_idx, const std::string &stage_name, const std::string which_side_of_temporal_edge_mates);
+    //> Evaluate precision/recall/ambiguity on candidate quads (from left/right temporal mates).
+    //> TP = candidate quads whose left and right cluster centers are near GT.
+    void Evaluate_Temporal_Edge_Pairs_on_Quads(
+        const std::vector<KF_Veridical_Quads> &temporal_quads_by_kf,
+        const size_t keyframe_idx, const size_t current_frame_idx, const std::string &stage_name);
+
+    //> Cluster storage backing Candidate_Quad_Entry pointers; [kf_idx][candidate_idx] -> (left, right) from same cf_stereo_edge_mate_index
+    std::vector<std::vector<std::pair<Temporal_CF_Edge_Cluster, Temporal_CF_Edge_Cluster>>> candidate_cluster_pairs_;
+
+    void print_eval_results_with_no_quads(const size_t keyframe_idx, const size_t current_frame_idx, const std::string &stage_name)
+    {
+        std::cout << "Quads Evaluation: Key Frame (" << keyframe_idx << ") <-> Current Frame (" << current_frame_idx << ") | Stage: " << stage_name << std::endl;
+        std::cout << " (NO CANDIDATE QUADS)" << std::endl;
+        std::cout << "========================================================\n" << std::endl;
+    }
 
     Dataset::Ptr dataset;
 };

--- a/include/Temporal_Matches.h
+++ b/include/Temporal_Matches.h
@@ -1,5 +1,5 @@
-#ifndef EBVO_H
-#define EBVO_H
+#ifndef TEMPORAL_MATCHES_H
+#define TEMPORAL_MATCHES_H
 
 #include "Dataset.h"
 #include "utility.h"
@@ -11,7 +11,7 @@
 #include <omp.h>
 #endif
 // =======================================================================================================
-// EBVO: Main structure of LEMS Edge-Based Visual Odometry
+// Temporal_Matches: Main structure of LEMS Edge-Based Visual Odometry
 //
 // ChangeLogs
 //    Jue  25-06-10    Created to reorganize VO.
@@ -21,17 +21,10 @@
 //> Jue Han (jhan192@brown.edu)
 // =======================================================================================================
 
-struct EdgeGTMatchInfo
-{
-    Edge edge;                        // the edge we want to find the correspondence
-    Edge gt_edge;                     // the ground truth correspondence edge in the next frame
-    std::vector<Edge> vertical_edges; // corresponding vertical edges in the next frame
-};
-
-class EBVO
+class Temporal_Matches
 {
 public:
-    EBVO(YAML::Node config_map);
+    Temporal_Matches(YAML::Node config_map);
 
     // Main function to perform edge-based visual odometry
     void PerformEdgeBasedVO();
@@ -82,10 +75,8 @@ public:
                                                    Stereo_Edge_Pairs &last_keyframe_stereo, Stereo_Edge_Pairs &current_frame_stereo,
                                                    SpatialGrid &spatial_grid, bool b_is_left, double gt_dist_threshold = 1.0);
     //> Evaluations
-    void Evaluate_KF_CF_Edge_Correspondences(const std::vector<temporal_edge_pair> &temporal_edge_mates,
-                                             size_t frame_idx, const std::string &stage_name, const std::string which_side_of_temporal_edge_mates);
-
-    std::tuple<std::vector<cv::Point2d>, std::vector<double>, std::vector<cv::Point2d>> PickRandomEdges(int patch_size, const std::vector<cv::Point2d> &edges, const std::vector<cv::Point2d> &ground_truth_right_edges, const std::vector<double> &orientations, size_t num_points, int img_width, int img_height);
+    void Evaluate_Temporal_Edge_Pairs(const std::vector<temporal_edge_pair> &temporal_edge_mates,
+                                      size_t frame_idx, const std::string &stage_name, const std::string which_side_of_temporal_edge_mates);
 
     double orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset);
 

--- a/include/Temporal_Matches.h
+++ b/include/Temporal_Matches.h
@@ -27,6 +27,16 @@ struct KF_Temporal_Edge_Quads
     std::vector<bool> b_is_TP;
 };
 
+struct Quad_Prepared_for_Constraints_Check
+{
+    size_t KF_stereo_mate_index;
+    size_t candidate_quad_index;
+    Eigen::Vector3d Gamma;
+    Eigen::Vector3d Gamma_bar;
+    Eigen::Vector3d Tangent;
+    Eigen::Vector3d Tangent_bar;
+};
+
 class Temporal_Matches
 {
 public:
@@ -82,6 +92,13 @@ public:
     double orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset);
 
     void finalize_temporal_quads(std::vector<KF_Temporal_Edge_Quads> &temporal_quads_by_kf);
+
+    void get_Gammas_and_Tangents_From_Quads(const KF_Temporal_Edge_Quads &kvq, const size_t candidate_idx, \
+        Eigen::Matrix3d inv_K, Eigen::Vector3d &Gamma, Eigen::Vector3d &Gamma_bar, Eigen::Vector3d &Tangent, Eigen::Vector3d &Tangent_bar);
+    
+    void test_Constraints_from_Two_Oriented_Points( \
+        const std::vector<KF_Temporal_Edge_Quads> &quads_by_kf, \
+        const size_t keyframe_idx, const size_t current_frame_idx);
 
     //> Write all quads to a CSV file (for debugging/analysis).
     void write_quads_to_file(const std::vector<KF_Temporal_Edge_Quads> &quads_by_kf,

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -40,6 +40,7 @@
 #define SIFT_THRESHOLD (500.0)
 //> precision-recall experiments
 #define DIST_TO_GT_THRESH (1.0) //> in pixels
+#define DIST_TO_GT_THRESH_QUADS (2.0) //> in pixels
 
 #define GRID_SIZE (15)     //> Size of the spatial grid cells in pixels
 

--- a/include/io.h
+++ b/include/io.h
@@ -162,9 +162,9 @@ inline void write_False_Negative_Edge_Clusters_to_file(Dataset &dataset, Stereo_
 //> write
 
 //> Write stereo edge pairs to file
-inline void write_Stereo_Edge_Pairs_to_file(Dataset &dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, int frame_idx)
+inline void write_Stereo_Edge_Pairs_to_file(Dataset::Ptr dataset, Stereo_Edge_Pairs &stereo_frame_edge_pairs, int frame_idx)
 {
-    std::string output_dir = dataset.get_output_path();
+    std::string output_dir = dataset->get_output_path();
     std::string stereo_frame_edge_pairs_filename = output_dir + "/stereo_frame_edge_pairs_frame_" + std::to_string(frame_idx) + ".txt";
     std::ofstream stereo_frame_edge_pairs_file(stereo_frame_edge_pairs_filename);
     stereo_frame_edge_pairs_file << "focused_edge_indices, GT_locations_from_focused_edges" << std::endl;

--- a/include/toed/cpu_toed.hpp
+++ b/include/toed/cpu_toed.hpp
@@ -69,8 +69,6 @@ namespace std
 
 class ThirdOrderEdgeDetectionCPU
 {
-
-  typedef std::shared_ptr<ThirdOrderEdgeDetectionCPU> Ptr;
   int img_height;
   int img_width;
   int interp_img_height;
@@ -112,6 +110,8 @@ public:
 
   std::vector<Edge> toed_edges;
   int Total_Num_Of_TOED;
+
+  typedef std::shared_ptr<ThirdOrderEdgeDetectionCPU> Ptr;
 };
 
 #endif // TOED_HPP

--- a/include/utility.h
+++ b/include/utility.h
@@ -45,6 +45,9 @@ public:
     double getTangentialDistance2EpipolarLine(Eigen::Vector3d Epip_Line_Coeffs, Eigen::Vector3d edge, double &x_intersection, double &y_intersection);
     double getTangentialDistance2EpipolarLine(Eigen::Vector3d Epip_Line_Coeffs, Eigen::VectorXd edges, int index, double &x_intersection, double &y_intersection);
 
+    Eigen::Vector3d backproject_2D_point_to_3D_point_using_rays( const Eigen::Matrix3d rel_R, const Eigen::Vector3d rel_T, const Eigen::Vector3d ray1, const Eigen::Vector3d ray2 );
+    Eigen::Vector3d reconstruct_3D_Tangent( const Eigen::Matrix3d rel_R, Eigen::Vector3d gamma1, Eigen::Vector3d gamma2, double theta1, double theta2 );
+
     std::pair<cv::Mat, cv::Mat> get_edge_patches(const Edge edge, const cv::Mat img, bool b_debug = false);
     std::pair<cv::Point2d, cv::Point2d> get_Orthogonal_Shifted_Points(const Edge edgel);
     std::pair<cv::Point2d, cv::Point2d> get_Orthogonal_Shifted_Points(const Edge edgel, double shift_magnitude);
@@ -64,6 +67,11 @@ public:
         const std::vector<Eigen::Matrix3d> &Rs, const std::vector<Eigen::Vector3d> &Ts, const Eigen::Matrix3d K);
 
     std::string cvMat_Type(int type);
+private:
+    //> basis vectors in 3D space
+    static Eigen::Vector3d e1;
+    static Eigen::Vector3d e2;
+    static Eigen::Vector3d e3;
 };
 
 template <typename T>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set (control_sources
         MotionTracker.cpp
         toed/cpu_toed.cpp
         Stereo_Matches.cpp
-        EBVO.cpp
+        Temporal_Matches.cpp
         Stereo_Iterator.cpp
         EdgeClusterer.cpp
 )

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -165,8 +165,7 @@ void Dataset::load_dataset(const std::string &dataset_type,
                            std::vector<cv::Mat> &left_ref_disparity_maps,
                            std::vector<cv::Mat> &right_ref_disparity_maps,
                            std::vector<cv::Mat> &left_occlusion_masks,
-                           std::vector<cv::Mat> &right_occlusion_masks,
-                           int num_pairs)
+                           std::vector<cv::Mat> &right_occlusion_masks)
 {
     if (dataset_type == "EuRoC")
     {
@@ -187,13 +186,13 @@ void Dataset::load_dataset(const std::string &dataset_type,
     {
         std::string stereo_pairs_path = file_info.dataset_path + "/" + file_info.sequence_name + "/stereo_pairs";
         stereo_iterator = Iterators::createETH3DIterator(stereo_pairs_path);
-        LoadETH3DDisparityMaps(stereo_pairs_path, num_pairs, left_ref_disparity_maps, right_ref_disparity_maps);
-        left_occlusion_masks = LoadETH3DOcclusionMasks(stereo_pairs_path, num_pairs, true);
-        right_occlusion_masks = LoadETH3DOcclusionMasks(stereo_pairs_path, num_pairs, false);
+        LoadETH3DDisparityMaps(stereo_pairs_path, left_ref_disparity_maps, right_ref_disparity_maps);
+        left_occlusion_masks = LoadETH3DOcclusionMasks(stereo_pairs_path, true);
+        right_occlusion_masks = LoadETH3DOcclusionMasks(stereo_pairs_path, false);
     }
 }
 
-std::vector<cv::Mat> Dataset::LoadETH3DOcclusionMasks(const std::string &stereo_pairs_path, int num_maps, bool left)
+std::vector<cv::Mat> Dataset::LoadETH3DOcclusionMasks(const std::string &stereo_pairs_path, bool left)
 {
     std::vector<cv::Mat> occlusion_masks;
     std::vector<std::string> stereo_folders;
@@ -208,7 +207,7 @@ std::vector<cv::Mat> Dataset::LoadETH3DOcclusionMasks(const std::string &stereo_
 
     std::sort(stereo_folders.begin(), stereo_folders.end());
 
-    for (int i = 0; i < std::min(num_maps, static_cast<int>(stereo_folders.size())); i++)
+    for (int i = 0; i < static_cast<int>(stereo_folders.size()); i++)
     {
         std::string folder_path = stereo_folders[i];
         std::string mask_filename = left ? "mask0nocc.png" : "mask1nocc.png";
@@ -232,7 +231,7 @@ std::vector<cv::Mat> Dataset::LoadETH3DOcclusionMasks(const std::string &stereo_
 
     return occlusion_masks;
 }
-void Dataset::LoadETH3DDisparityMaps(const std::string &stereo_pairs_path, int num_maps, std::vector<cv::Mat> &left_disparity_maps, std::vector<cv::Mat> &right_disparity_maps)
+void Dataset::LoadETH3DDisparityMaps(const std::string &stereo_pairs_path, std::vector<cv::Mat> &left_disparity_maps, std::vector<cv::Mat> &right_disparity_maps)
 {
     std::vector<std::string> stereo_folders;
 
@@ -246,7 +245,7 @@ void Dataset::LoadETH3DDisparityMaps(const std::string &stereo_pairs_path, int n
 
     std::sort(stereo_folders.begin(), stereo_folders.end());
 
-    for (int i = 0; i < std::min(num_maps, static_cast<int>(stereo_folders.size())); i++)
+    for (int i = 0; i < static_cast<int>(stereo_folders.size()); i++)
     {
         std::string folder_path = stereo_folders[i];
         std::string disparity_pfm_left_path = folder_path + "/disp0GT.pfm";

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -144,6 +144,12 @@ void Pipeline::get_Temporal_Edge_Correspondences() {
         right_spatial_grids, false, 1.0);
     std::cout << "Size of veridical edge pairs (right) = " << right_temporal_edge_mates.size() << std::endl;
 
+    std::vector<KF_Veridical_Quads> veridical_quads_by_kf = temporal_matches_engine->find_Veridical_Quads(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
+    size_t num_veridical_quads = 0;
+    for (const auto &kvq : veridical_quads_by_kf)
+        num_veridical_quads += kvq.veridical_CF_stereo_mates.size();
+    std::cout << "Veridical quads: " << veridical_quads_by_kf.size() << " KF stereo correspondences, " << num_veridical_quads << " total quads" << std::endl;
+
     temporal_matches_engine->get_Temporal_Edge_Pairs(
         current_frame_stereo_edge_mates,
         left_temporal_edge_mates, right_temporal_edge_mates,

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -131,7 +131,7 @@ void Pipeline::get_Temporal_Edge_Correspondences() {
     //> `temporal_quads_by_kf` is a struct that stores quads from KF stereo edge pairs
     //> One KF stereo edge pair could pair up with multiple veridical CF stereo edge pairs.
     //> The structure `temporal_quads_by_kf` contains the veridical CF stereo edge pairs, and the matching CF stereo edge pairs
-    std::vector<KF_Veridical_Quads> temporal_quads_by_kf;
+    std::vector<KF_Temporal_Edge_Quads> temporal_quads_by_kf;
     temporal_matches_engine->build_Veridical_Quads( temporal_quads_by_kf, keyframe_stereo_edge_mates, current_frame_stereo_edge_mates, keyframe_stereo_left_constructor, current_frame_stereo_left_constructor, left_spatial_grids, right_spatial_grids);
 
     //> Quad-centric pipeline: build veridical quads, apply filters, optionally convert to temporal pairs for backward compatibility
@@ -143,6 +143,9 @@ void Pipeline::get_Temporal_Edge_Correspondences() {
         keyframe_stereo_left_constructor, current_frame_stereo_left_constructor,
         keyframe, current_frame,
         stereo_key_frame_idx, stereo_current_frame_idx);
+
+    //> write quads to a file
+    temporal_matches_engine->write_quads_to_file(temporal_quads_by_kf, stereo_key_frame_idx, stereo_current_frame_idx);
 
     send_control_to_main = true;
 }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -147,6 +147,11 @@ void Pipeline::get_Temporal_Edge_Correspondences() {
     //> write quads to a file
     temporal_matches_engine->write_quads_to_file(temporal_quads_by_kf, stereo_key_frame_idx, stereo_current_frame_idx);
 
+    temporal_matches_engine->test_Constraints_from_Two_Oriented_Points(
+        temporal_quads_by_kf,
+        stereo_key_frame_idx,
+        stereo_current_frame_idx);
+
     send_control_to_main = true;
 }
 

--- a/src/Stereo_Matches.cpp
+++ b/src/Stereo_Matches.cpp
@@ -1311,16 +1311,16 @@ Frame_Evaluation_Metrics Stereo_Matches::get_Stereo_Edge_Pairs(Dataset::Ptr data
 
     //> Apply Best-Nearly-Best test with both NCC and SIFT scores
     apply_Best_Nearly_Best_Test(stereo_frame_edge_pairs, BNB_NCC, "output_files", frame_idx, true);
-    Evaluate_Stereo_Edge_Correspondences(stereo_frame_edge_pairs, frame_idx, "BNB Test NCC",
+    Evaluate_Stereo_Edge_Correspondences(stereo_frame_edge_pairs, frame_idx, "BNB-NCC",
                                          recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg,
                                          evaluation_statistics);
-    frame_metrics.stages["BNB Test"] = {recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg};
+    frame_metrics.stages["BNB-NCC"] = {recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg};
 
     apply_Best_Nearly_Best_Test(stereo_frame_edge_pairs, BNB_SIFT, "output_files", frame_idx, false);
-    Evaluate_Stereo_Edge_Correspondences(stereo_frame_edge_pairs, frame_idx, "BNB Test SIFT",
+    Evaluate_Stereo_Edge_Correspondences(stereo_frame_edge_pairs, frame_idx, "BNB-SIFT",
                                          recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg,
                                          evaluation_statistics);
-    frame_metrics.stages["BNB Test_Strict"] = {recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg};
+    frame_metrics.stages["BNB-SIFT"] = {recall_per_image, precision_per_image, precision_pair_per_image, num_of_target_edges_per_source_edge_avg};
 
     //> Shift edges to the epipolar line and cluster them to consolidate redundant edge hypothesis
     bool b_shift_to_epipolar_line = true;

--- a/src/Temporal_Matches.cpp
+++ b/src/Temporal_Matches.cpp
@@ -891,10 +891,6 @@ void Temporal_Matches::test_Constraints_from_Two_Oriented_Points( \
         {
             Quad_Prepared_for_Constraints_Check q;
             get_Gammas_and_Tangents_From_Quads(kvq, j, inv_K, q.Gamma, q.Gamma_bar, q.Tangent, q.Tangent_bar);
-            if (k == 5160 && j == 0) {
-                std::cout << "Here: " << std::endl;
-                std::cout << kvq.b_is_TP[j] << std::endl;
-            }
             if (kvq.b_is_TP[j]) {
                 veridical_quads.push_back({k, j, q.Gamma, q.Gamma_bar, q.Tangent, q.Tangent_bar});
             }
@@ -906,15 +902,14 @@ void Temporal_Matches::test_Constraints_from_Two_Oriented_Points( \
 
     //> write the c1 values to a file
     std::string output_dir = dataset->get_output_path();
-    std::string file_name = output_dir + "/c1_values_kf" + std::to_string(keyframe_idx) + "_cf" + std::to_string(current_frame_idx) + ".txt";
-    std::ofstream file_input(file_name);
-    if (!file_input.is_open())
+    std::string file_name_c1 = output_dir + "/c1_values_kf" + std::to_string(keyframe_idx) + "_cf" + std::to_string(current_frame_idx) + ".txt";
+    std::ofstream file_input_c1(file_name_c1);
+    if (!file_input_c1.is_open())
         return;
 
-    //> length constraints
     const size_t N = 1000;
-    std::vector<double> veridical_c1_values(N);
-    std::vector<double> non_veridical_c1_values(N);
+    // std::vector<double> veridical_c1_values(N);
+    // std::vector<double> non_veridical_c1_values(N);
     for (size_t i = 0; i < N; i++) {
         //> randomly pick two veridical and non-veridical quads
         const auto &q1_v = veridical_quads[rand() % veridical_quads.size()];
@@ -922,22 +917,24 @@ void Temporal_Matches::test_Constraints_from_Two_Oriented_Points( \
         const auto &q1_nv = non_veridical_quads[rand() % non_veridical_quads.size()];
         const auto &q2_nv = non_veridical_quads[rand() % non_veridical_quads.size()];
 
-        //> test length constraints
+        //> Constraint 1: 
         double length_Gamma_v = (q1_v.Gamma - q2_v.Gamma).norm();
         double length_Gamma_bar_v = (q1_v.Gamma_bar - q2_v.Gamma_bar).norm();
-        veridical_c1_values[i] = length_Gamma_v - length_Gamma_bar_v;
+        double veridical_c1_values = length_Gamma_v - length_Gamma_bar_v;
+        double veridical_c1_values_normalized = veridical_c1_values / length_Gamma_v;
 
         double length_Gamma_nv = (q1_nv.Gamma - q2_nv.Gamma).norm();
         double length_Gamma_bar_nv = (q1_nv.Gamma_bar - q2_nv.Gamma_bar).norm();
-        non_veridical_c1_values[i] = length_Gamma_nv - length_Gamma_bar_nv;
+        double non_veridical_c1_values = length_Gamma_nv - length_Gamma_bar_nv;
+        double non_veridical_c1_values_normalized = non_veridical_c1_values / length_Gamma_nv;
 
-        file_input << q1_v.KF_stereo_mate_index << " " << q1_v.candidate_quad_index << " " \
-                   << q2_v.KF_stereo_mate_index << " " << q2_v.candidate_quad_index << " " << veridical_c1_values[i] << " " \
+        file_input_c1 << q1_v.KF_stereo_mate_index << " " << q1_v.candidate_quad_index << " " \
+                   << q2_v.KF_stereo_mate_index << " " << q2_v.candidate_quad_index << " " << veridical_c1_values << " " << veridical_c1_values_normalized << " " \
                    << q1_nv.KF_stereo_mate_index << " " << q1_nv.candidate_quad_index << " " \
-                   << q2_nv.KF_stereo_mate_index << " " << q2_nv.candidate_quad_index << " " << non_veridical_c1_values[i] << std::endl;
+                   << q2_nv.KF_stereo_mate_index << " " << q2_nv.candidate_quad_index << " " << non_veridical_c1_values << " " << non_veridical_c1_values_normalized << std::endl;
     }
 
-    file_input.close();
+    file_input_c1.close();
 }
 
 void Temporal_Matches::write_quads_to_file(const std::vector<KF_Temporal_Edge_Quads> &quads_by_kf,

--- a/src/Temporal_Matches.cpp
+++ b/src/Temporal_Matches.cpp
@@ -4,15 +4,15 @@
 #include <cmath>
 #include <chrono>
 #include <omp.h>
-#include "EBVO.h"
+#include "Temporal_Matches.h"
 #include "EdgeClusterer.h"
 #include "definitions.h"
 #include <opencv2/core/eigen.hpp>
 
-EBVO::EBVO(YAML::Node config_map) : dataset(config_map) {}
+Temporal_Matches::Temporal_Matches(YAML::Node config_map) : dataset(config_map) {}
 
 //> MARK: MAIN CODE OF EDGE VO
-void EBVO::PerformEdgeBasedVO()
+void Temporal_Matches::PerformEdgeBasedVO()
 {
     // The main processing function that performs edge-based visual odometry on a sequence of stereo image pairs.
     // It loads images, detects edges, matches them, and evaluates the matching performance.
@@ -176,61 +176,61 @@ void EBVO::PerformEdgeBasedVO()
             //> Now that the GT edge correspondences are constructed between the keyframe and the current frame, we can apply various filters from the beginning
             //> Stage 1: Apply spatial grid to the current frame
             apply_spatial_grid_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, left_spatial_grids, 30.0, true);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
             apply_spatial_grid_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, right_spatial_grids, 30.0, false);
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
 
             //> Stage 2: Do orientation filtering
             apply_orientation_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, true);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
             apply_orientation_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, false);
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
 
             //> Stage 3: Do NCC
             apply_NCC_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.left_image, current_frame.left_image, true);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
             apply_NCC_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.right_image, current_frame.right_image, false);
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
 
             //> Stage 4: SIFT filtering
             apply_SIFT_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, true);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
             apply_SIFT_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, false);
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
 
             //> Stage 5: Best-Nearly-Best filtering (NCC scoring)
             apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.8, "NCC");
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
             apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.8, "NCC");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
 
             //> Stage 6: Best-Nearly-Best filtering (SIFT scoring)
             apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.3, "SIFT");
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
             apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.3, "SIFT");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
 
             //> Stage 7: Photometric refinement
             apply_photometric_refinement(left_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, true);
             apply_photometric_refinement(right_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, false);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
 
             //> Stage 8: Temporal edge clustering (merge nearby CF candidates per KF mate)
             apply_temporal_edge_clustering(left_temporal_edge_mates, true);
             apply_temporal_edge_clustering(right_temporal_edge_mates, true);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
 
             //> Stage 9: Mate consistency filtering
             apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
 
             //> Stage 10: Length consistency filtering
             apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
-            Evaluate_KF_CF_Edge_Correspondences(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
-            Evaluate_KF_CF_Edge_Correspondences(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
+            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
+            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
             break;
         }
 
@@ -242,7 +242,7 @@ void EBVO::PerformEdgeBasedVO()
     }
 }
 
-void EBVO::add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids)
+void Temporal_Matches::add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids)
 {
     // Pre-compute grid cell assignments in parallel (read-only)
     std::vector<std::pair<int, int>> left_edge_to_grid(stereo_edge_mates.size());
@@ -281,7 +281,7 @@ void EBVO::add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &
     }
 }
 
-void EBVO::Find_Veridical_Edge_Correspondences_on_CF(
+void Temporal_Matches::Find_Veridical_Edge_Correspondences_on_CF(
     std::vector<temporal_edge_pair> &temporal_edge_mates,
     const std::vector<final_stereo_edge_pair> &KF_stereo_edge_mates,
     const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
@@ -389,7 +389,7 @@ void EBVO::Find_Veridical_Edge_Correspondences_on_CF(
     }
 }
 
-void EBVO::ProcessEdges(const cv::Mat &image,
+void Temporal_Matches::ProcessEdges(const cv::Mat &image,
                         std::shared_ptr<ThirdOrderEdgeDetectionCPU> &toed,
                         std::vector<Edge> &edges)
 {
@@ -398,7 +398,7 @@ void EBVO::ProcessEdges(const cv::Mat &image,
     edges = toed->toed_edges;
 }
 
-double EBVO::orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset)
+double Temporal_Matches::orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset)
 {
     // Step 1: Get the stereo baseline rotation (Left -> Right)
     Eigen::Matrix3d R_stereo = dataset.get_relative_rot_left_to_right();
@@ -442,7 +442,7 @@ double EBVO::orientation_mapping(const Edge &e_left, const Edge &e_right, const 
     return atan2(t.y(), t.x());
 }
 
-void EBVO::apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, SpatialGrid &spatial_grid, double grid_radius, bool b_is_left)
+void Temporal_Matches::apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, SpatialGrid &spatial_grid, double grid_radius, bool b_is_left)
 {
     //> For each temporal edge pair (KF mate + projected point on CF), find candidate CF stereo edge mate indices using the spatial grid
 #pragma omp parallel for schedule(dynamic, 64)
@@ -466,7 +466,7 @@ void EBVO::apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &tempora
     }
 }
 
-void EBVO::apply_SIFT_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
+void Temporal_Matches::apply_SIFT_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                 const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                 double sift_dist_threshold, bool b_is_left)
 {
@@ -547,7 +547,7 @@ void EBVO::apply_SIFT_filtering(std::vector<temporal_edge_pair> &temporal_edge_m
     }
 }
 
-void EBVO::apply_best_nearly_best_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, double threshold, const std::string scoring_type)
+void Temporal_Matches::apply_best_nearly_best_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, double threshold, const std::string scoring_type)
 {
     bool is_NCC = scoring_type == "NCC";
 #pragma omp parallel for schedule(dynamic)
@@ -599,7 +599,7 @@ void EBVO::apply_best_nearly_best_filtering(std::vector<temporal_edge_pair> &tem
     }
 }
 
-void EBVO::apply_photometric_refinement(std::vector<temporal_edge_pair> &temporal_edge_mates,
+void Temporal_Matches::apply_photometric_refinement(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                         const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                         const StereoFrame &keyframe, const StereoFrame &current_frame,
                                         bool b_is_left)
@@ -653,7 +653,7 @@ void EBVO::apply_photometric_refinement(std::vector<temporal_edge_pair> &tempora
     }
 }
 
-void EBVO::apply_temporal_edge_clustering(std::vector<temporal_edge_pair> &temporal_edge_mates, bool b_cluster_by_orientation)
+void Temporal_Matches::apply_temporal_edge_clustering(std::vector<temporal_edge_pair> &temporal_edge_mates, bool b_cluster_by_orientation)
 {
     //> Cluster nearby CF edge candidates per temporal pair, mirroring consolidate_redundant_edge_hypothesis in stereo
     for (temporal_edge_pair &tp : temporal_edge_mates)
@@ -728,12 +728,12 @@ void EBVO::apply_temporal_edge_clustering(std::vector<temporal_edge_pair> &tempo
     }
 }
 
-void EBVO::apply_length_constraint(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
+void Temporal_Matches::apply_length_constraint(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
                                    std::vector<temporal_edge_pair> &right_temporal_edge_mates,
                                    const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates)
 {
 }
-void EBVO::apply_mate_consistency_filtering(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
+void Temporal_Matches::apply_mate_consistency_filtering(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
                                             std::vector<temporal_edge_pair> &right_temporal_edge_mates)
 {
     //> For each left temporal pair, its stereo mate (right) must have the same CF candidate in the right temporal pair.
@@ -829,7 +829,7 @@ void EBVO::apply_mate_consistency_filtering(std::vector<temporal_edge_pair> &lef
     }
 }
 
-void EBVO::apply_NCC_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
+void Temporal_Matches::apply_NCC_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                double ncc_val_threshold, const cv::Mat &keyframe_image, const cv::Mat &current_image, bool b_is_left)
 {
@@ -910,7 +910,7 @@ void EBVO::apply_NCC_filtering(std::vector<temporal_edge_pair> &temporal_edge_ma
     }
 }
 
-void EBVO::min_Edge_Photometric_Residual_by_Gauss_Newton(
+void Temporal_Matches::min_Edge_Photometric_Residual_by_Gauss_Newton(
     /* inputs */
     Edge kf_edge, Edge cf_edge, Eigen::Vector2d init_disp, const cv::Mat &kf_image_undistorted,
     const cv::Mat &cf_image_undistorted, const cv::Mat &cf_image_gradients_x, const cv::Mat &cf_image_gradients_y,
@@ -1028,7 +1028,7 @@ void EBVO::min_Edge_Photometric_Residual_by_Gauss_Newton(
     refined_disparity = d;
 }
 
-void EBVO::apply_orientation_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
+void Temporal_Matches::apply_orientation_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates,
                                        const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates,
                                        double orientation_threshold, bool b_is_left)
 {
@@ -1097,7 +1097,7 @@ void EBVO::apply_orientation_filtering(std::vector<temporal_edge_pair> &temporal
     }
 }
 
-void EBVO::Evaluate_KF_CF_Edge_Correspondences(const std::vector<temporal_edge_pair> &temporal_edge_mates,
+void Temporal_Matches::Evaluate_Temporal_Edge_Pairs(const std::vector<temporal_edge_pair> &temporal_edge_mates,
                                                size_t frame_idx, const std::string &stage_name, const std::string which_side_of_temporal_edge_mates)
 {
     if (temporal_edge_mates.empty())

--- a/src/Temporal_Matches.cpp
+++ b/src/Temporal_Matches.cpp
@@ -9,237 +9,291 @@
 #include "definitions.h"
 #include <opencv2/core/eigen.hpp>
 
-Temporal_Matches::Temporal_Matches(YAML::Node config_map) : dataset(config_map) {}
+Temporal_Matches::Temporal_Matches(Dataset::Ptr dataset) : dataset(std::move(dataset)) {}
+
+void Temporal_Matches::get_Temporal_Edge_Pairs( \
+    std::vector<final_stereo_edge_pair> &current_frame_stereo_edge_mates, \
+    std::vector<temporal_edge_pair> &left_temporal_edge_mates, std::vector<temporal_edge_pair> &right_temporal_edge_mates, \
+    const SpatialGrid &left_spatial_grids, const SpatialGrid &right_spatial_grids, \
+    const StereoFrame &keyframe, const StereoFrame &current_frame, \
+    size_t frame_idx)
+{
+    //> Now that the GT edge correspondences are constructed between the keyframe and the current frame, we can apply various filters from the beginning
+    //> Stage 1: Apply spatial grid to the current frame
+    apply_spatial_grid_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, left_spatial_grids, 30.0, true);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
+    apply_spatial_grid_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, right_spatial_grids, 30.0, false);
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
+
+    //> Stage 2: Do orientation filtering
+    apply_orientation_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, true);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
+    apply_orientation_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, false);
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
+
+    //> Stage 3: Do NCC
+    apply_NCC_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, keyframe.left_image, current_frame.left_image, true);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
+    apply_NCC_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, keyframe.right_image, current_frame.right_image, false);
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
+
+    //> Stage 4: SIFT filtering
+    apply_SIFT_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, true);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
+    apply_SIFT_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, false);
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
+
+    //> Stage 5: Best-Nearly-Best filtering (NCC scoring)
+    apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.8, "NCC");
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
+    apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.8, "NCC");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
+
+    //> Stage 6: Best-Nearly-Best filtering (SIFT scoring)
+    apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.3, "SIFT");
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
+    apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.3, "SIFT");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
+
+    //> Stage 7: Photometric refinement
+    apply_photometric_refinement(left_temporal_edge_mates, current_frame_stereo_edge_mates, keyframe, current_frame, true);
+    apply_photometric_refinement(right_temporal_edge_mates, current_frame_stereo_edge_mates, keyframe, current_frame, false);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
+
+    //> Stage 8: Temporal edge clustering (merge nearby CF candidates per KF mate)
+    apply_temporal_edge_clustering(left_temporal_edge_mates, true);
+    apply_temporal_edge_clustering(right_temporal_edge_mates, true);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
+
+    //> Stage 9: Mate consistency filtering
+    apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
+
+    //> Stage 10: Length consistency filtering
+    apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
+    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
+    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
+}
 
 //> MARK: MAIN CODE OF EDGE VO
 void Temporal_Matches::PerformEdgeBasedVO()
 {
-    // The main processing function that performs edge-based visual odometry on a sequence of stereo image pairs.
-    // It loads images, detects edges, matches them, and evaluates the matching performance.
     int num_pairs = 100000;
-    std::vector<cv::Mat> left_ref_disparity_maps;
-    std::vector<cv::Mat> right_ref_disparity_maps;
-    std::vector<cv::Mat> left_occlusion_masks, right_occlusion_masks;
+    // std::vector<cv::Mat> left_ref_disparity_maps;
+    // std::vector<cv::Mat> right_ref_disparity_maps;
+    // std::vector<cv::Mat> left_occlusion_masks, right_occlusion_masks;
 
     //> load stereo iterator and read disparity
-    dataset.load_dataset(dataset.get_dataset_type(), left_ref_disparity_maps, right_ref_disparity_maps, left_occlusion_masks, right_occlusion_masks, num_pairs);
-
-    std::vector<double> left_intr = dataset.left_intr();
-    std::vector<double> right_intr = dataset.right_intr();
-
-    cv::Mat left_calib = (cv::Mat_<double>(3, 3) << left_intr[0], 0, left_intr[2], 0, left_intr[1], left_intr[3], 0, 0, 1);
-    cv::Mat right_calib = (cv::Mat_<double>(3, 3) << right_intr[0], 0, right_intr[2], 0, right_intr[1], right_intr[3], 0, 0, 1);
-
-    cv::Mat left_dist_coeff_mat = (cv::Mat_<double>(1, 4) << dataset.left_dist_coeffs()[0], dataset.left_dist_coeffs()[1], dataset.left_dist_coeffs()[2], dataset.left_dist_coeffs()[3]);
-    cv::Mat right_dist_coeff_mat = (cv::Mat_<double>(1, 4) << dataset.right_dist_coeffs()[0], dataset.right_dist_coeffs()[1], dataset.right_dist_coeffs()[2], dataset.right_dist_coeffs()[3]);
+    // dataset->load_dataset(dataset->get_dataset_type(), left_ref_disparity_maps, right_ref_disparity_maps, left_occlusion_masks, right_occlusion_masks, num_pairs);
 
     LOG_INFO("Start looping over all image pairs");
-    // now we change the logic, we will do previous frame and current frame instead
-    StereoFrame last_keyframe, current_frame;
+    // StereoFrame last_keyframe, current_frame;
     //> Initialize
-    Stereo_Edge_Pairs last_keyframe_stereo_left, current_frame_stereo_left;
+    // Stereo_Edge_Pairs last_keyframe_stereo_left, current_frame_stereo_left;
 
     //> Engine for constructing stereo edge correspondences
-    Stereo_Matches stereo_edge_matcher;
+    // Stereo_Matches stereo_edge_matcher;
 
     //> Final 1-1 stereo edge pairs for keyframe and current frame
-    std::vector<final_stereo_edge_pair> keyframe_stereo_edge_mates;
-    std::vector<final_stereo_edge_pair> current_frame_stereo_edge_mates;
+    // std::vector<final_stereo_edge_pair> keyframe_stereo_edge_mates;
+    // std::vector<final_stereo_edge_pair> current_frame_stereo_edge_mates;
 
     //> Keyframe <-> current frame edge pairs
-    std::vector<temporal_edge_pair> left_temporal_edge_mates;
-    std::vector<temporal_edge_pair> right_temporal_edge_mates;
+    // std::vector<temporal_edge_pair> left_temporal_edge_mates;
+    // std::vector<temporal_edge_pair> right_temporal_edge_mates;
 
-    cv::Ptr<cv::SIFT> sift = cv::SIFT::create();
 
-    bool b_is_keyframe = true;
+    // bool b_is_keyframe = true;
 
-    size_t frame_idx = 0;
-    while (dataset.stereo_iterator->hasNext() && num_pairs - frame_idx >= 0)
-    {
-        if (!dataset.stereo_iterator->getNext(current_frame))
-        {
-            std::cout << "No more image pairs to process" << std::endl;
-            break;
-        }
+    // size_t frame_idx = 0;
+    // while (dataset->stereo_iterator->hasNext() && num_pairs - frame_idx >= 0)
+    // {
+    //     if (!dataset->stereo_iterator->getNext(current_frame))
+    //     {
+    //         std::cout << "No more image pairs to process" << std::endl;
+    //         break;
+    //     }
 
-        const cv::Mat &left_disparity_map = (frame_idx < left_ref_disparity_maps.size()) ? left_ref_disparity_maps[frame_idx] : cv::Mat();
-        const cv::Mat &right_disparity_map = (frame_idx < right_ref_disparity_maps.size()) ? right_ref_disparity_maps[frame_idx] : cv::Mat();
+    //     const cv::Mat &left_disparity_map = (frame_idx < left_ref_disparity_maps.size()) ? left_ref_disparity_maps[frame_idx] : cv::Mat();
+    //     const cv::Mat &right_disparity_map = (frame_idx < right_ref_disparity_maps.size()) ? right_ref_disparity_maps[frame_idx] : cv::Mat();
 
-        //> FOr now, this is optional
-        const cv::Mat &left_occlusion_mask = (frame_idx < left_occlusion_masks.size()) ? left_occlusion_masks[frame_idx] : cv::Mat();
-        const cv::Mat &right_occlusion_mask = (frame_idx < right_occlusion_masks.size()) ? right_occlusion_masks[frame_idx] : cv::Mat();
+    //     //> FOr now, this is optional
+    //     const cv::Mat &left_occlusion_mask = (frame_idx < left_occlusion_masks.size()) ? left_occlusion_masks[frame_idx] : cv::Mat();
+    //     const cv::Mat &right_occlusion_mask = (frame_idx < right_occlusion_masks.size()) ? right_occlusion_masks[frame_idx] : cv::Mat();
 
-        std::cout << std::endl
-                  << "Image Pair #" << frame_idx << std::endl;
+    //     std::cout << std::endl
+    //               << "Image Pair #" << frame_idx << std::endl;
 
-        cv::Mat left_cur_undistorted, right_cur_undistorted;
-        cv::undistort(current_frame.left_image, left_cur_undistorted, left_calib, left_dist_coeff_mat);
-        cv::undistort(current_frame.right_image, right_cur_undistorted, right_calib, right_dist_coeff_mat);
-        current_frame.left_image_undistorted = left_cur_undistorted;
-        current_frame.right_image_undistorted = right_cur_undistorted;
+    //     cv::Mat left_cur_undistorted, right_cur_undistorted;
+    //     cv::undistort(current_frame.left_image, left_cur_undistorted, dataset->get_left_calib_matrix_cvMat(), dataset->get_left_dist_coeff_mat());
+    //     cv::undistort(current_frame.right_image, right_cur_undistorted, dataset->get_right_calib_matrix_cvMat(), dataset->get_right_dist_coeff_mat());
+    //     current_frame.left_image_undistorted = left_cur_undistorted;
+    //     current_frame.right_image_undistorted = right_cur_undistorted;
 
-        util_compute_Img_Gradients(current_frame.left_image_undistorted, current_frame.left_image_gradients_x, current_frame.left_image_gradients_y);
-        util_compute_Img_Gradients(current_frame.right_image_undistorted, current_frame.right_image_gradients_x, current_frame.right_image_gradients_y);
+    //     util_compute_Img_Gradients(current_frame.left_image_undistorted, current_frame.left_image_gradients_x, current_frame.left_image_gradients_y);
+    //     util_compute_Img_Gradients(current_frame.right_image_undistorted, current_frame.right_image_gradients_x, current_frame.right_image_gradients_y);
 
-        if (dataset.get_num_imgs() == 0)
-        {
-            dataset.set_height(left_cur_undistorted.rows);
-            dataset.set_width(left_cur_undistorted.cols);
+    //     if (dataset->get_num_imgs() == 0)
+    //     {
+    //         dataset->set_height(left_cur_undistorted.rows);
+    //         dataset->set_width(left_cur_undistorted.cols);
 
-            TOED = std::shared_ptr<ThirdOrderEdgeDetectionCPU>(new ThirdOrderEdgeDetectionCPU(dataset.get_height(), dataset.get_width()));
+    //         TOED = std::shared_ptr<ThirdOrderEdgeDetectionCPU>(new ThirdOrderEdgeDetectionCPU(dataset->get_height(), dataset->get_width()));
 
-            // Initialize the spatial grids with a cell size of defined GRID_SIZE
-            left_spatial_grids = SpatialGrid(dataset.get_width(), dataset.get_height(), GRID_SIZE);
-            right_spatial_grids = SpatialGrid(dataset.get_width(), dataset.get_height(), GRID_SIZE);
-        }
+    //         // Initialize the spatial grids with a cell size of defined GRID_SIZE
+    //         left_spatial_grids = SpatialGrid(dataset->get_width(), dataset->get_height(), GRID_SIZE);
+    //         right_spatial_grids = SpatialGrid(dataset->get_width(), dataset->get_height(), GRID_SIZE);
+    //     }
 
-        ProcessEdges(left_cur_undistorted, TOED, dataset.left_edges);
-        std::cout << "Number of edges on the left image: " << dataset.left_edges.size() << std::endl;
-        current_frame.left_edges = dataset.left_edges;
+    //     ProcessEdges(left_cur_undistorted, TOED, dataset->left_edges);
+    //     std::cout << "Number of edges on the left image: " << dataset->left_edges.size() << std::endl;
+    //     current_frame.left_edges = dataset->left_edges;
 
-        ProcessEdges(right_cur_undistorted, TOED, dataset.right_edges);
-        std::cout << "Number of edges on the right image: " << dataset.right_edges.size() << std::endl;
-        current_frame.right_edges = dataset.right_edges;
-        dataset.increment_num_imgs();
-        std::cout << std::endl;
+    //     ProcessEdges(right_cur_undistorted, TOED, dataset->right_edges);
+    //     std::cout << "Number of edges on the right image: " << dataset->right_edges.size() << std::endl;
+    //     current_frame.right_edges = dataset->right_edges;
+    //     dataset->increment_num_imgs();
+    //     std::cout << std::endl;
 
-        if (b_is_keyframe)
-        {
-            //> Update last keyframe
-            last_keyframe = current_frame;
-            last_keyframe_stereo_left.clean_up_vector_data_structures();
-            last_keyframe_stereo_left.stereo_frame = &last_keyframe;
-            last_keyframe_stereo_left.left_disparity_map = left_disparity_map;
-            last_keyframe_stereo_left.right_disparity_map = right_disparity_map;
+    //     if (b_is_keyframe)
+    //     {
+    //         //> Update last keyframe
+    //         last_keyframe = current_frame;
+    //         last_keyframe_stereo_left.clean_up_vector_data_structures();
+    //         last_keyframe_stereo_left.stereo_frame = &last_keyframe;
+    //         last_keyframe_stereo_left.left_disparity_map = left_disparity_map;
+    //         last_keyframe_stereo_left.right_disparity_map = right_disparity_map;
 
-            //> For each left edge, get the corresponding GT location (not right edge) on the right image, and the triangulated 3D point in the left camera coordinate
-            stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, last_keyframe, last_keyframe_stereo_left, true);
-            std::cout << "Complete calculating GT locations for left edges of the keyframe (previous frame)..." << std::endl;
-            //> Construct a GT stereo edge pool
-            stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, last_keyframe, last_keyframe_stereo_left, true);
-            std::cout << "Size of stereo edge correspondences pool = " << last_keyframe_stereo_left.focused_edge_indices.size() << std::endl;
+    //         //> For each left edge, get the corresponding GT location (not right edge) on the right image, and the triangulated 3D point in the left camera coordinate
+    //         stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, last_keyframe, last_keyframe_stereo_left, true);
+    //         std::cout << "Complete calculating GT locations for left edges of the keyframe (previous frame)..." << std::endl;
+    //         //> Construct a GT stereo edge pool
+    //         stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, last_keyframe, last_keyframe_stereo_left, true);
+    //         std::cout << "Size of stereo edge correspondences pool = " << last_keyframe_stereo_left.focused_edge_indices.size() << std::endl;
 
-            last_keyframe_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
+    //         last_keyframe_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
 
-            //> construct stereo edge correspondences for the keyframe frame
-            Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, last_keyframe_stereo_left, frame_idx);
+    //         //> construct stereo edge correspondences for the keyframe frame
+    //         Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, last_keyframe_stereo_left, frame_idx);
 
-            //> Finalize the stereo edge pairs for the keyframe
-            stereo_edge_matcher.finalize_stereo_edge_mates(last_keyframe_stereo_left, keyframe_stereo_edge_mates);
+    //         //> Finalize the stereo edge pairs for the keyframe
+    //         stereo_edge_matcher.finalize_stereo_edge_mates(last_keyframe_stereo_left, keyframe_stereo_edge_mates);
 
-            b_is_keyframe = false;
-        }
-        else
-        {
-            current_frame_stereo_left.clean_up_vector_data_structures();
-            current_frame_stereo_left.stereo_frame = &current_frame;
-            current_frame_stereo_left.left_disparity_map = left_disparity_map;
-            current_frame_stereo_left.right_disparity_map = right_disparity_map;
+    //         b_is_keyframe = false;
+    //     }
+    //     else
+    //     {
+    //         current_frame_stereo_left.clean_up_vector_data_structures();
+    //         current_frame_stereo_left.stereo_frame = &current_frame;
+    //         current_frame_stereo_left.left_disparity_map = left_disparity_map;
+    //         current_frame_stereo_left.right_disparity_map = right_disparity_map;
 
-            stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, current_frame, current_frame_stereo_left, true);
-            std::cout << "Complete calculating GT locations for left edges of the current frame..." << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
+    //         stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, current_frame, current_frame_stereo_left, true);
+    //         std::cout << "Complete calculating GT locations for left edges of the current frame..." << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
 
-            //> Construct a GT stereo edge pool
-            stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, current_frame, current_frame_stereo_left, true);
-            std::cout << "Size of stereo edge correspondences pool for left edges= " << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
+    //         //> Construct a GT stereo edge pool
+    //         stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, current_frame, current_frame_stereo_left, true);
+    //         std::cout << "Size of stereo edge correspondences pool for left edges= " << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
 
-            // Construct TOED-to-Stereo_Edge_Pairs mapping for the current frame
-            current_frame_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
+    //         // Construct TOED-to-Stereo_Edge_Pairs mapping for the current frame
+    //         current_frame_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
 
-            //> construct stereo edge correspondences for the current frame
-            Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, current_frame_stereo_left, frame_idx);
+    //         //> construct stereo edge correspondences for the current frame
+    //         Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, current_frame_stereo_left, frame_idx);
 
-            //> Finalize the stereo edge pairs for the keyframe
-            stereo_edge_matcher.finalize_stereo_edge_mates(current_frame_stereo_left, current_frame_stereo_edge_mates);
+    //         //> Finalize the stereo edge pairs for the keyframe
+    //         stereo_edge_matcher.finalize_stereo_edge_mates(current_frame_stereo_left, current_frame_stereo_edge_mates);
 
-            //> Assign edges to spatial grids
-            add_edges_to_spatial_grid(current_frame_stereo_edge_mates, left_spatial_grids, right_spatial_grids);
-            std::cout << "Finish adding left and right edges of the current frame to spatial grid with cell size " << GRID_SIZE << std::endl;
+    //         //> Assign edges to spatial grids
+    //         add_edges_to_spatial_grid(current_frame_stereo_edge_mates, left_spatial_grids, right_spatial_grids);
+    //         std::cout << "Finish adding left and right edges of the current frame to spatial grid with cell size " << GRID_SIZE << std::endl;
 
-            //> Construct correspondences structure between last keyframe and the current frame
-            Find_Veridical_Edge_Correspondences_on_CF(
-                left_temporal_edge_mates,
-                keyframe_stereo_edge_mates,
-                current_frame_stereo_edge_mates,
-                last_keyframe_stereo_left, current_frame_stereo_left,
-                left_spatial_grids, true, 1.0);
-            std::cout << "Size of veridical edge pairs (left) = " << left_temporal_edge_mates.size() << std::endl;
-            Find_Veridical_Edge_Correspondences_on_CF(
-                right_temporal_edge_mates,
-                keyframe_stereo_edge_mates,
-                current_frame_stereo_edge_mates,
-                last_keyframe_stereo_left, current_frame_stereo_left,
-                right_spatial_grids, false, 1.0);
-            std::cout << "Size of veridical edge pairs (right) = " << right_temporal_edge_mates.size() << std::endl;
+    //         //> Construct correspondences structure between last keyframe and the current frame
+    //         Find_Veridical_Edge_Correspondences_on_CF(
+    //             left_temporal_edge_mates,
+    //             keyframe_stereo_edge_mates,
+    //             current_frame_stereo_edge_mates,
+    //             last_keyframe_stereo_left, current_frame_stereo_left,
+    //             left_spatial_grids, true, 1.0);
+    //         std::cout << "Size of veridical edge pairs (left) = " << left_temporal_edge_mates.size() << std::endl;
+    //         Find_Veridical_Edge_Correspondences_on_CF(
+    //             right_temporal_edge_mates,
+    //             keyframe_stereo_edge_mates,
+    //             current_frame_stereo_edge_mates,
+    //             last_keyframe_stereo_left, current_frame_stereo_left,
+    //             right_spatial_grids, false, 1.0);
+    //         std::cout << "Size of veridical edge pairs (right) = " << right_temporal_edge_mates.size() << std::endl;
 
-            //> Now that the GT edge correspondences are constructed between the keyframe and the current frame, we can apply various filters from the beginning
-            //> Stage 1: Apply spatial grid to the current frame
-            apply_spatial_grid_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, left_spatial_grids, 30.0, true);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
-            apply_spatial_grid_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, right_spatial_grids, 30.0, false);
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
+    //         //> Now that the GT edge correspondences are constructed between the keyframe and the current frame, we can apply various filters from the beginning
+    //         //> Stage 1: Apply spatial grid to the current frame
+    //         apply_spatial_grid_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, left_spatial_grids, 30.0, true);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
+    //         apply_spatial_grid_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, right_spatial_grids, 30.0, false);
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
 
-            //> Stage 2: Do orientation filtering
-            apply_orientation_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, true);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
-            apply_orientation_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, false);
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
+    //         //> Stage 2: Do orientation filtering
+    //         apply_orientation_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, true);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
+    //         apply_orientation_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, false);
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
 
-            //> Stage 3: Do NCC
-            apply_NCC_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.left_image, current_frame.left_image, true);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
-            apply_NCC_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.right_image, current_frame.right_image, false);
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
+    //         //> Stage 3: Do NCC
+    //         apply_NCC_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.left_image, current_frame.left_image, true);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
+    //         apply_NCC_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.right_image, current_frame.right_image, false);
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
 
-            //> Stage 4: SIFT filtering
-            apply_SIFT_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, true);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
-            apply_SIFT_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, false);
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
+    //         //> Stage 4: SIFT filtering
+    //         apply_SIFT_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, true);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
+    //         apply_SIFT_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, false);
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
 
-            //> Stage 5: Best-Nearly-Best filtering (NCC scoring)
-            apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.8, "NCC");
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
-            apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.8, "NCC");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
+    //         //> Stage 5: Best-Nearly-Best filtering (NCC scoring)
+    //         apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.8, "NCC");
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
+    //         apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.8, "NCC");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
 
-            //> Stage 6: Best-Nearly-Best filtering (SIFT scoring)
-            apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.3, "SIFT");
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
-            apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.3, "SIFT");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
+    //         //> Stage 6: Best-Nearly-Best filtering (SIFT scoring)
+    //         apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.3, "SIFT");
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
+    //         apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.3, "SIFT");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
 
-            //> Stage 7: Photometric refinement
-            apply_photometric_refinement(left_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, true);
-            apply_photometric_refinement(right_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, false);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
+    //         //> Stage 7: Photometric refinement
+    //         apply_photometric_refinement(left_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, true);
+    //         apply_photometric_refinement(right_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, false);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
 
-            //> Stage 8: Temporal edge clustering (merge nearby CF candidates per KF mate)
-            apply_temporal_edge_clustering(left_temporal_edge_mates, true);
-            apply_temporal_edge_clustering(right_temporal_edge_mates, true);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
+    //         //> Stage 8: Temporal edge clustering (merge nearby CF candidates per KF mate)
+    //         apply_temporal_edge_clustering(left_temporal_edge_mates, true);
+    //         apply_temporal_edge_clustering(right_temporal_edge_mates, true);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
 
-            //> Stage 9: Mate consistency filtering
-            apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
+    //         //> Stage 9: Mate consistency filtering
+    //         apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
 
-            //> Stage 10: Length consistency filtering
-            apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
-            Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
-            Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
-            break;
-        }
+    //         //> Stage 10: Length consistency filtering
+    //         apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
+    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
+    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
+    //         break;
+    //     }
 
-        frame_idx++;
-        if (frame_idx > 1)
-        {
-            break;
-        }
-    }
+    //     frame_idx++;
+    //     if (frame_idx > 1)
+    //     {
+    //         break;
+    //     }
+    // }
 }
 
 void Temporal_Matches::add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids)
@@ -313,23 +367,23 @@ void Temporal_Matches::Find_Veridical_Edge_Correspondences_on_CF(
             Eigen::Vector3d projected_point;
             if (b_is_left)
             {
-                projected_point = dataset.get_left_calib_matrix() * Gamma_in_left_CF;
+                projected_point = dataset->get_left_calib_matrix() * Gamma_in_left_CF;
             }
             else
             {
-                Eigen::Vector3d Gamma_in_right_CF = dataset.get_relative_rot_left_to_right() * Gamma_in_left_CF + dataset.get_relative_transl_left_to_right();
-                projected_point = dataset.get_right_calib_matrix() * Gamma_in_right_CF;
+                Eigen::Vector3d Gamma_in_right_CF = dataset->get_relative_rot_left_to_right() * Gamma_in_left_CF + dataset->get_relative_transl_left_to_right();
+                projected_point = dataset->get_right_calib_matrix() * Gamma_in_right_CF;
             }
             projected_point /= projected_point.z();
 
             double projected_orientation = orientation_mapping(
                 kf_mate->left_edge,
                 kf_mate->right_edge,
-                projected_point, b_is_left, *last_keyframe_stereo.stereo_frame, *current_frame_stereo.stereo_frame, dataset);
+                projected_point, b_is_left, *last_keyframe_stereo.stereo_frame, *current_frame_stereo.stereo_frame, *dataset);
 
             cv::Point2d projected_point_cv(projected_point.x(), projected_point.y());
             if (projected_point.x() <= img_margin || projected_point.y() <= img_margin ||
-                projected_point.x() >= dataset.get_width() - img_margin || projected_point.y() >= dataset.get_height() - img_margin)
+                projected_point.x() >= dataset->get_width() - img_margin || projected_point.y() >= dataset->get_height() - img_margin)
                 continue;
 
             std::vector<int> current_candidate_edge_indices = spatial_grid.getCandidatesWithinRadius(projected_point_cv, search_radius);
@@ -389,15 +443,6 @@ void Temporal_Matches::Find_Veridical_Edge_Correspondences_on_CF(
     }
 }
 
-void Temporal_Matches::ProcessEdges(const cv::Mat &image,
-                        std::shared_ptr<ThirdOrderEdgeDetectionCPU> &toed,
-                        std::vector<Edge> &edges)
-{
-    std::cout << "Running third-order edge detector..." << std::endl;
-    toed->get_Third_Order_Edges(image);
-    edges = toed->toed_edges;
-}
-
 double Temporal_Matches::orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset)
 {
     // Step 1: Get the stereo baseline rotation (Left -> Right)
@@ -442,7 +487,7 @@ double Temporal_Matches::orientation_mapping(const Edge &e_left, const Edge &e_r
     return atan2(t.y(), t.x());
 }
 
-void Temporal_Matches::apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, SpatialGrid &spatial_grid, double grid_radius, bool b_is_left)
+void Temporal_Matches::apply_spatial_grid_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates, const SpatialGrid &spatial_grid, double grid_radius, bool b_is_left)
 {
     //> For each temporal edge pair (KF mate + projected point on CF), find candidate CF stereo edge mate indices using the spatial grid
 #pragma omp parallel for schedule(dynamic, 64)
@@ -537,7 +582,8 @@ void Temporal_Matches::apply_SIFT_filtering(std::vector<temporal_edge_pair> &tem
         is_veridical.insert(is_veridical.end(), thread_local_is_veridical[tid].begin(), thread_local_is_veridical[tid].end());
     }
 
-    std::string output_dir = dataset.get_output_path();
+#if RECORD_FILTER_DISTRIBUTIONS
+    std::string output_dir = dataset->get_output_path();
     size_t frame_idx = 0;
     if (!output_dir.empty() && !sift_distances.empty())
     {
@@ -545,6 +591,7 @@ void Temporal_Matches::apply_SIFT_filtering(std::vector<temporal_edge_pair> &tem
         Stereo_Matches stereo_matcher;
         stereo_matcher.record_Filter_Distribution("temporal_sift_distance_" + side, sift_distances, is_veridical, output_dir, frame_idx);
     }
+#endif
 }
 
 void Temporal_Matches::apply_best_nearly_best_filtering(std::vector<temporal_edge_pair> &temporal_edge_mates, double threshold, const std::string scoring_type)
@@ -900,7 +947,8 @@ void Temporal_Matches::apply_NCC_filtering(std::vector<temporal_edge_pair> &temp
         is_veridical.insert(is_veridical.end(), thread_local_is_veridical[tid].begin(), thread_local_is_veridical[tid].end());
     }
 
-    std::string output_dir = dataset.get_output_path();
+#if RECORD_FILTER_DISTRIBUTIONS
+    std::string output_dir = dataset->get_output_path();
     size_t frame_idx = 0;
     if (!output_dir.empty() && !ncc_scores.empty())
     {
@@ -908,6 +956,7 @@ void Temporal_Matches::apply_NCC_filtering(std::vector<temporal_edge_pair> &temp
         Stereo_Matches stereo_matcher;
         stereo_matcher.record_Filter_Distribution("temporal_ncc_score_" + side, ncc_scores, is_veridical, output_dir, frame_idx);
     }
+#endif
 }
 
 void Temporal_Matches::min_Edge_Photometric_Residual_by_Gauss_Newton(
@@ -1087,7 +1136,8 @@ void Temporal_Matches::apply_orientation_filtering(std::vector<temporal_edge_pai
         is_veridical.insert(is_veridical.end(), thread_local_is_veridical[tid].begin(), thread_local_is_veridical[tid].end());
     }
 
-    std::string output_dir = dataset.get_output_path();
+#if RECORD_FILTER_DISTRIBUTIONS
+    std::string output_dir = dataset->get_output_path();
     size_t frame_idx = 0; // You may want to pass this as a parameter
     if (!output_dir.empty() && !orientation_differences.empty())
     {
@@ -1095,6 +1145,7 @@ void Temporal_Matches::apply_orientation_filtering(std::vector<temporal_edge_pai
         Stereo_Matches stereo_matcher;
         stereo_matcher.record_Filter_Distribution("temporal_orientation_difference_" + side, orientation_differences, is_veridical, output_dir, frame_idx);
     }
+#endif
 }
 
 void Temporal_Matches::Evaluate_Temporal_Edge_Pairs(const std::vector<temporal_edge_pair> &temporal_edge_mates,

--- a/src/Temporal_Matches.cpp
+++ b/src/Temporal_Matches.cpp
@@ -71,229 +71,6 @@ void Temporal_Matches::get_Temporal_Edge_Pairs( \
     apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
     Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
     Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
-
-    //> Stage 10: Length consistency filtering
-    apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
-    Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
-    Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
-}
-
-//> MARK: MAIN CODE OF EDGE VO
-void Temporal_Matches::PerformEdgeBasedVO()
-{
-    int num_pairs = 100000;
-    // std::vector<cv::Mat> left_ref_disparity_maps;
-    // std::vector<cv::Mat> right_ref_disparity_maps;
-    // std::vector<cv::Mat> left_occlusion_masks, right_occlusion_masks;
-
-    //> load stereo iterator and read disparity
-    // dataset->load_dataset(dataset->get_dataset_type(), left_ref_disparity_maps, right_ref_disparity_maps, left_occlusion_masks, right_occlusion_masks, num_pairs);
-
-    LOG_INFO("Start looping over all image pairs");
-    // StereoFrame last_keyframe, current_frame;
-    //> Initialize
-    // Stereo_Edge_Pairs last_keyframe_stereo_left, current_frame_stereo_left;
-
-    //> Engine for constructing stereo edge correspondences
-    // Stereo_Matches stereo_edge_matcher;
-
-    //> Final 1-1 stereo edge pairs for keyframe and current frame
-    // std::vector<final_stereo_edge_pair> keyframe_stereo_edge_mates;
-    // std::vector<final_stereo_edge_pair> current_frame_stereo_edge_mates;
-
-    //> Keyframe <-> current frame edge pairs
-    // std::vector<temporal_edge_pair> left_temporal_edge_mates;
-    // std::vector<temporal_edge_pair> right_temporal_edge_mates;
-
-
-    // bool b_is_keyframe = true;
-
-    // size_t frame_idx = 0;
-    // while (dataset->stereo_iterator->hasNext() && num_pairs - frame_idx >= 0)
-    // {
-    //     if (!dataset->stereo_iterator->getNext(current_frame))
-    //     {
-    //         std::cout << "No more image pairs to process" << std::endl;
-    //         break;
-    //     }
-
-    //     const cv::Mat &left_disparity_map = (frame_idx < left_ref_disparity_maps.size()) ? left_ref_disparity_maps[frame_idx] : cv::Mat();
-    //     const cv::Mat &right_disparity_map = (frame_idx < right_ref_disparity_maps.size()) ? right_ref_disparity_maps[frame_idx] : cv::Mat();
-
-    //     //> FOr now, this is optional
-    //     const cv::Mat &left_occlusion_mask = (frame_idx < left_occlusion_masks.size()) ? left_occlusion_masks[frame_idx] : cv::Mat();
-    //     const cv::Mat &right_occlusion_mask = (frame_idx < right_occlusion_masks.size()) ? right_occlusion_masks[frame_idx] : cv::Mat();
-
-    //     std::cout << std::endl
-    //               << "Image Pair #" << frame_idx << std::endl;
-
-    //     cv::Mat left_cur_undistorted, right_cur_undistorted;
-    //     cv::undistort(current_frame.left_image, left_cur_undistorted, dataset->get_left_calib_matrix_cvMat(), dataset->get_left_dist_coeff_mat());
-    //     cv::undistort(current_frame.right_image, right_cur_undistorted, dataset->get_right_calib_matrix_cvMat(), dataset->get_right_dist_coeff_mat());
-    //     current_frame.left_image_undistorted = left_cur_undistorted;
-    //     current_frame.right_image_undistorted = right_cur_undistorted;
-
-    //     util_compute_Img_Gradients(current_frame.left_image_undistorted, current_frame.left_image_gradients_x, current_frame.left_image_gradients_y);
-    //     util_compute_Img_Gradients(current_frame.right_image_undistorted, current_frame.right_image_gradients_x, current_frame.right_image_gradients_y);
-
-    //     if (dataset->get_num_imgs() == 0)
-    //     {
-    //         dataset->set_height(left_cur_undistorted.rows);
-    //         dataset->set_width(left_cur_undistorted.cols);
-
-    //         TOED = std::shared_ptr<ThirdOrderEdgeDetectionCPU>(new ThirdOrderEdgeDetectionCPU(dataset->get_height(), dataset->get_width()));
-
-    //         // Initialize the spatial grids with a cell size of defined GRID_SIZE
-    //         left_spatial_grids = SpatialGrid(dataset->get_width(), dataset->get_height(), GRID_SIZE);
-    //         right_spatial_grids = SpatialGrid(dataset->get_width(), dataset->get_height(), GRID_SIZE);
-    //     }
-
-    //     ProcessEdges(left_cur_undistorted, TOED, dataset->left_edges);
-    //     std::cout << "Number of edges on the left image: " << dataset->left_edges.size() << std::endl;
-    //     current_frame.left_edges = dataset->left_edges;
-
-    //     ProcessEdges(right_cur_undistorted, TOED, dataset->right_edges);
-    //     std::cout << "Number of edges on the right image: " << dataset->right_edges.size() << std::endl;
-    //     current_frame.right_edges = dataset->right_edges;
-    //     dataset->increment_num_imgs();
-    //     std::cout << std::endl;
-
-    //     if (b_is_keyframe)
-    //     {
-    //         //> Update last keyframe
-    //         last_keyframe = current_frame;
-    //         last_keyframe_stereo_left.clean_up_vector_data_structures();
-    //         last_keyframe_stereo_left.stereo_frame = &last_keyframe;
-    //         last_keyframe_stereo_left.left_disparity_map = left_disparity_map;
-    //         last_keyframe_stereo_left.right_disparity_map = right_disparity_map;
-
-    //         //> For each left edge, get the corresponding GT location (not right edge) on the right image, and the triangulated 3D point in the left camera coordinate
-    //         stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, last_keyframe, last_keyframe_stereo_left, true);
-    //         std::cout << "Complete calculating GT locations for left edges of the keyframe (previous frame)..." << std::endl;
-    //         //> Construct a GT stereo edge pool
-    //         stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, last_keyframe, last_keyframe_stereo_left, true);
-    //         std::cout << "Size of stereo edge correspondences pool = " << last_keyframe_stereo_left.focused_edge_indices.size() << std::endl;
-
-    //         last_keyframe_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
-
-    //         //> construct stereo edge correspondences for the keyframe frame
-    //         Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, last_keyframe_stereo_left, frame_idx);
-
-    //         //> Finalize the stereo edge pairs for the keyframe
-    //         stereo_edge_matcher.finalize_stereo_edge_mates(last_keyframe_stereo_left, keyframe_stereo_edge_mates);
-
-    //         b_is_keyframe = false;
-    //     }
-    //     else
-    //     {
-    //         current_frame_stereo_left.clean_up_vector_data_structures();
-    //         current_frame_stereo_left.stereo_frame = &current_frame;
-    //         current_frame_stereo_left.left_disparity_map = left_disparity_map;
-    //         current_frame_stereo_left.right_disparity_map = right_disparity_map;
-
-    //         stereo_edge_matcher.Find_Stereo_GT_Locations(dataset, left_disparity_map, current_frame, current_frame_stereo_left, true);
-    //         std::cout << "Complete calculating GT locations for left edges of the current frame..." << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
-
-    //         //> Construct a GT stereo edge pool
-    //         stereo_edge_matcher.get_Stereo_Edge_GT_Pairs(dataset, current_frame, current_frame_stereo_left, true);
-    //         std::cout << "Size of stereo edge correspondences pool for left edges= " << current_frame_stereo_left.focused_edge_indices.size() << std::endl;
-
-    //         // Construct TOED-to-Stereo_Edge_Pairs mapping for the current frame
-    //         current_frame_stereo_left.construct_toed_left_id_to_Stereo_Edge_Pairs_left_id_map();
-
-    //         //> construct stereo edge correspondences for the current frame
-    //         Frame_Evaluation_Metrics metrics = stereo_edge_matcher.get_Stereo_Edge_Pairs(dataset, current_frame_stereo_left, frame_idx);
-
-    //         //> Finalize the stereo edge pairs for the keyframe
-    //         stereo_edge_matcher.finalize_stereo_edge_mates(current_frame_stereo_left, current_frame_stereo_edge_mates);
-
-    //         //> Assign edges to spatial grids
-    //         add_edges_to_spatial_grid(current_frame_stereo_edge_mates, left_spatial_grids, right_spatial_grids);
-    //         std::cout << "Finish adding left and right edges of the current frame to spatial grid with cell size " << GRID_SIZE << std::endl;
-
-    //         //> Construct correspondences structure between last keyframe and the current frame
-    //         Find_Veridical_Edge_Correspondences_on_CF(
-    //             left_temporal_edge_mates,
-    //             keyframe_stereo_edge_mates,
-    //             current_frame_stereo_edge_mates,
-    //             last_keyframe_stereo_left, current_frame_stereo_left,
-    //             left_spatial_grids, true, 1.0);
-    //         std::cout << "Size of veridical edge pairs (left) = " << left_temporal_edge_mates.size() << std::endl;
-    //         Find_Veridical_Edge_Correspondences_on_CF(
-    //             right_temporal_edge_mates,
-    //             keyframe_stereo_edge_mates,
-    //             current_frame_stereo_edge_mates,
-    //             last_keyframe_stereo_left, current_frame_stereo_left,
-    //             right_spatial_grids, false, 1.0);
-    //         std::cout << "Size of veridical edge pairs (right) = " << right_temporal_edge_mates.size() << std::endl;
-
-    //         //> Now that the GT edge correspondences are constructed between the keyframe and the current frame, we can apply various filters from the beginning
-    //         //> Stage 1: Apply spatial grid to the current frame
-    //         apply_spatial_grid_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, left_spatial_grids, 30.0, true);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Limited Disparity", "Left");
-    //         apply_spatial_grid_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, right_spatial_grids, 30.0, false);
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Limited Disparity", "Right");
-
-    //         //> Stage 2: Do orientation filtering
-    //         apply_orientation_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, true);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Orientation Filtering", "Left");
-    //         apply_orientation_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 35.0, false);
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Orientation Filtering", "Right");
-
-    //         //> Stage 3: Do NCC
-    //         apply_NCC_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.left_image, current_frame.left_image, true);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "NCC Filtering", "Left");
-    //         apply_NCC_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 0.6, last_keyframe.right_image, current_frame.right_image, false);
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "NCC Filtering", "Right");
-
-    //         //> Stage 4: SIFT filtering
-    //         apply_SIFT_filtering(left_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, true);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "SIFT Filtering", "Left");
-    //         apply_SIFT_filtering(right_temporal_edge_mates, current_frame_stereo_edge_mates, 500.0, false);
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "SIFT Filtering", "Right");
-
-    //         //> Stage 5: Best-Nearly-Best filtering (NCC scoring)
-    //         apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.8, "NCC");
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Left");
-    //         apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.8, "NCC");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB NCC Filtering", "Right");
-
-    //         //> Stage 6: Best-Nearly-Best filtering (SIFT scoring)
-    //         apply_best_nearly_best_filtering(left_temporal_edge_mates, 0.3, "SIFT");
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Left");
-    //         apply_best_nearly_best_filtering(right_temporal_edge_mates, 0.3, "SIFT");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "BNB SIFT Filtering", "Right");
-
-    //         //> Stage 7: Photometric refinement
-    //         apply_photometric_refinement(left_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, true);
-    //         apply_photometric_refinement(right_temporal_edge_mates, current_frame_stereo_edge_mates, last_keyframe, current_frame, false);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Photometric Refinement", "Left");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Photometric Refinement", "Right");
-
-    //         //> Stage 8: Temporal edge clustering (merge nearby CF candidates per KF mate)
-    //         apply_temporal_edge_clustering(left_temporal_edge_mates, true);
-    //         apply_temporal_edge_clustering(right_temporal_edge_mates, true);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Left");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Temporal Edge Clustering", "Right");
-
-    //         //> Stage 9: Mate consistency filtering
-    //         apply_mate_consistency_filtering(left_temporal_edge_mates, right_temporal_edge_mates);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Left");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Mate Consistency Filtering", "Right");
-
-    //         //> Stage 10: Length consistency filtering
-    //         apply_length_constraint(left_temporal_edge_mates, right_temporal_edge_mates, current_frame_stereo_edge_mates);
-    //         Evaluate_Temporal_Edge_Pairs(left_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Left");
-    //         Evaluate_Temporal_Edge_Pairs(right_temporal_edge_mates, frame_idx, "Length Consistency Filtering", "Right");
-    //         break;
-    //     }
-
-    //     frame_idx++;
-    //     if (frame_idx > 1)
-    //     {
-    //         break;
-    //     }
-    // }
 }
 
 void Temporal_Matches::add_edges_to_spatial_grid(const std::vector<final_stereo_edge_pair> &stereo_edge_mates, SpatialGrid &left_spatial_grids, SpatialGrid &right_spatial_grids)
@@ -441,6 +218,77 @@ void Temporal_Matches::Find_Veridical_Edge_Correspondences_on_CF(
                                    std::make_move_iterator(thread_temporal_edge_mates[tid].begin()),
                                    std::make_move_iterator(thread_temporal_edge_mates[tid].end()));
     }
+}
+
+std::vector<KF_Veridical_Quads> Temporal_Matches::find_Veridical_Quads(
+    const std::vector<temporal_edge_pair> &left_temporal_edge_mates,
+    const std::vector<temporal_edge_pair> &right_temporal_edge_mates,
+    const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates)
+{
+    // Map KF stereo mate pointer -> corresponding right temporal pair
+    std::unordered_map<const final_stereo_edge_pair *, const temporal_edge_pair *> kf_to_right_tp;
+    kf_to_right_tp.reserve(right_temporal_edge_mates.size());
+    for (const auto &rtp : right_temporal_edge_mates)
+    {
+        kf_to_right_tp[rtp.KF_stereo_edge_mate] = &rtp;
+    }
+
+    const int num_threads = omp_get_max_threads();
+    // Per-thread: KF_stereo_mate -> veridical CF stereo mate pointers
+    std::vector<std::unordered_map<const final_stereo_edge_pair *, std::unordered_set<const final_stereo_edge_pair *>>> thread_kf_to_cfs(num_threads);
+
+#pragma omp parallel for schedule(dynamic)
+    for (int i = 0; i < static_cast<int>(left_temporal_edge_mates.size()); ++i)
+    {
+        const int tid = omp_get_thread_num();
+        const auto &ltp = left_temporal_edge_mates[i];
+
+        const final_stereo_edge_pair *kf_stereo_mate = ltp.KF_stereo_edge_mate;
+        if (!kf_stereo_mate)
+            continue;
+
+        auto it = kf_to_right_tp.find(kf_stereo_mate);
+        if (it == kf_to_right_tp.end())
+            continue; // no matching right temporal pair for this KF mate
+
+        const temporal_edge_pair &rtp = *it->second;
+
+        std::unordered_set<int> right_veridical(
+            rtp.veridical_CF_stereo_edge_mate_indices.begin(),
+            rtp.veridical_CF_stereo_edge_mate_indices.end());
+
+        auto &cf_set = thread_kf_to_cfs[tid][kf_stereo_mate];
+        for (int cf_idx : ltp.veridical_CF_stereo_edge_mate_indices)
+        {
+            if (!right_veridical.count(cf_idx))
+                continue;
+            if (cf_idx < 0 || cf_idx >= static_cast<int>(CF_stereo_edge_mates.size()))
+                continue;
+            cf_set.insert(&CF_stereo_edge_mates[cf_idx]);
+        }
+    }
+
+    //> Merge thread maps: same KF may appear in multiple threads
+    std::unordered_map<const final_stereo_edge_pair *, std::unordered_set<const final_stereo_edge_pair *>> merged;
+    for (int t = 0; t < num_threads; ++t)
+    {
+        for (const auto &kv : thread_kf_to_cfs[t])
+        {
+            for (const auto *cf : kv.second)
+                merged[kv.first].insert(cf);
+        }
+    }
+
+    std::vector<KF_Veridical_Quads> veridical_quads_by_kf;
+    veridical_quads_by_kf.reserve(merged.size());
+    for (auto &kv : merged)
+    {
+        KF_Veridical_Quads entry;
+        entry.KF_stereo_mate = kv.first;
+        entry.veridical_CF_stereo_mates.assign(kv.second.begin(), kv.second.end());
+        veridical_quads_by_kf.push_back(std::move(entry));
+    }
+    return veridical_quads_by_kf;
 }
 
 double Temporal_Matches::orientation_mapping(const Edge &e_left, const Edge &e_right, const Eigen::Vector3d projected_point, bool is_left_cam, const StereoFrame &last_keyframe, const StereoFrame &current_frame, Dataset &dataset)
@@ -775,11 +623,6 @@ void Temporal_Matches::apply_temporal_edge_clustering(std::vector<temporal_edge_
     }
 }
 
-void Temporal_Matches::apply_length_constraint(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
-                                   std::vector<temporal_edge_pair> &right_temporal_edge_mates,
-                                   const std::vector<final_stereo_edge_pair> &CF_stereo_edge_mates)
-{
-}
 void Temporal_Matches::apply_mate_consistency_filtering(std::vector<temporal_edge_pair> &left_temporal_edge_mates,
                                             std::vector<temporal_edge_pair> &right_temporal_edge_mates)
 {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -25,6 +25,11 @@
 
 Utility::Utility() {}
 
+//> Define and initialize static members (basis vectors in 3D space)
+Eigen::Vector3d Utility::e1 = Eigen::Vector3d::UnitX();
+Eigen::Vector3d Utility::e2 = Eigen::Vector3d::UnitY();
+Eigen::Vector3d Utility::e3 = Eigen::Vector3d::UnitZ();
+
 //> Normal distance from an edge to the corresponding epipolar line
 double Utility::getNormalDistance2EpipolarLine( Eigen::Vector3d Epip_Line_Coeffs, Eigen::Vector3d edge, double &epiline_x, double &epiline_y ) 
 {
@@ -71,6 +76,25 @@ std::pair<cv::Point2d, cv::Point2d> Utility::get_Orthogonal_Shifted_Points(const
     cv::Point2d shifted_point_minus(shifted_x2, shifted_y2);
 
     return {shifted_point_plus, shifted_point_minus};
+}
+
+Eigen::Vector3d Utility::backproject_2D_point_to_3D_point_using_rays( const Eigen::Matrix3d rel_R, const Eigen::Vector3d rel_T, const Eigen::Vector3d ray1, const Eigen::Vector3d ray2 )
+{
+    //> Analytically find the depth
+    double numerator = e1.dot(rel_T) - (e3.dot(rel_T)) * e1.dot(ray2);
+    double denominator = e3.dot(rel_R * ray1) * (e1.dot(ray2)) - e1.dot(rel_R * ray1);
+    double rho1 = numerator / denominator;
+    return rho1 * ray1;
+}
+
+Eigen::Vector3d Utility::reconstruct_3D_Tangent( const Eigen::Matrix3d rel_R, Eigen::Vector3d gamma1, Eigen::Vector3d gamma2, double theta1, double theta2 )
+{
+  Eigen::Vector3d t1(cos(theta1), sin(theta1), 0);
+  Eigen::Vector3d t2(cos(theta2), sin(theta2), 0);
+
+  Eigen::Vector3d T_3D = -(gamma2.dot(t2.cross(rel_R * t1))) * gamma1 + (gamma2.dot(t2.cross(rel_R * gamma1))) * t1;
+  T_3D.normalize();
+  return T_3D;
 }
 
 std::pair<cv::Point2d, cv::Point2d> Utility::get_Orthogonal_Shifted_Points(const Edge edgel, double shift_magnitude)
@@ -157,19 +181,6 @@ std::pair<cv::Mat, cv::Mat> Utility::get_edge_patches(const Edge edge, const cv:
         patch_val_minus.convertTo(patch_val_minus, CV_32F);
 
     return {patch_val_plus, patch_val_minus};
-}
-
-//> Display images and features via OpenCV
-void Utility::Display_Feature_Correspondences(cv::Mat Img1, cv::Mat Img2,
-                                              std::vector<cv::KeyPoint> KeyPoint1, std::vector<cv::KeyPoint> KeyPoint2,
-                                              std::vector<cv::DMatch> Good_Matches)
-{
-  //> Credit: matcher_simple.cpp from the official OpenCV
-  cv::namedWindow("matches", 1);
-  cv::Mat img_matches;
-  cv::drawMatches(Img1, KeyPoint1, Img2, KeyPoint2, Good_Matches, img_matches);
-  cv::imshow("matches", img_matches);
-  cv::waitKey(0);
 }
 
 Eigen::Vector3d Utility::two_view_linear_triangulation(

--- a/test/test_optical_flow.cpp
+++ b/test/test_optical_flow.cpp
@@ -1,12 +1,7 @@
 #include <iostream>
 #include <opencv2/opencv.hpp>
-#include "../include/EBVO.h"
+#include "../include/Temporal_Matches.h"
 #include "../include/OpticalFlow.h"
-
-/**
- * Test program for optical flow functionality in EBVO
- * This demonstrates how to use the new optical flow features
- */
 
 void test_optical_flow_basic()
 {


### PR DESCRIPTION
The code organizes stereo and temporal (sequential) edge correspondences to serve for a visual odometry